### PR TITLE
ENH: Enable quadninja support

### DIFF
--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -13,6 +13,7 @@ autoreconf --install
 ./configure \
     --prefix=$PREFIX \
     --enable-static=no \
+    --enable-quadninja=yes \
     --with-avholo="$FFLAGS -lavh_olo" \
     --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
     FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -8,11 +8,10 @@ autoreconf --install
 
 ./configure --help
 
-# Remove static library to comply with CFEP-18
-# https://github.com/conda-forge/cfep/blob/main/cfep-18.md
 ./configure \
     --prefix=$PREFIX \
     --enable-static=yes \
+    --enable-quadninja=yes \
     --with-avholo="$FFLAGS -lavh_olo" \
     --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
     FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
@@ -28,4 +27,4 @@ make install
 make clean
 
 # Remove automatically built shared library
-rm $PREFIX/lib/libninja.so.*
+rm $PREFIX/lib/libninja.so*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - update-version-number-to-v1.2.0.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: {{ name }}-hep-ph
@@ -68,27 +68,45 @@ outputs:
         # c.f. https://github.com/conda/conda-build/issues/3075
         - test ! -f $PREFIX/lib/libninja.la
         - test ! -f $PREFIX/lib/libninja.a
-        - test -f $PREFIX/include/ninja/zero_float.hh
-        - test -f $PREFIX/include/ninja/types.hh
-        - test -f $PREFIX/include/ninja/tensor_ninja.hh
-        - test -f $PREFIX/include/ninja/ninja_in.hh
-        - test -f $PREFIX/include/ninja/ninja.hh
-        - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
-        - test -f $PREFIX/include/ninja/static_arrays.hh
-        - test -f $PREFIX/include/ninja/spinors.hh
-        - test -f $PREFIX/include/ninja/s_mat.hh
-        - test -f $PREFIX/include/ninja/rambo.hh
-        - test -f $PREFIX/include/ninja/num_defs.hh
-        - test -f $PREFIX/include/ninja/ninjanumgen.hh
-        - test -f $PREFIX/include/ninja/momentum.hh
-        - test -f $PREFIX/include/ninja/looptools.hh
-        - test -f $PREFIX/include/ninja/integral_library.hh
-        - test -f $PREFIX/include/ninja/avholo.hh
-        - test -f $PREFIX/include/ninja/ninja_config.h
-        - test -f $PREFIX/include/ninjavholo.mod
-        - test -f $PREFIX/include/ninjago_module.mod
-        - test -f $PREFIX/include/mninja.mod
         - test -f $PREFIX/bin/ninja-config
+        - test -f $PREFIX/include/mninja.mod
+        - test -f $PREFIX/include/ninja/avholo.hh
+        - test -f $PREFIX/include/ninja/integral_library.hh
+        - test -f $PREFIX/include/ninja/looptools.hh
+        - test -f $PREFIX/include/ninja/momentum.hh
+        - test -f $PREFIX/include/ninja/ninja.hh
+        - test -f $PREFIX/include/ninja/ninja_config.h
+        - test -f $PREFIX/include/ninja/ninja_in.hh
+        - test -f $PREFIX/include/ninja/ninjanumgen.hh
+        - test -f $PREFIX/include/ninja/num_defs.hh
+        - test -f $PREFIX/include/ninja/rambo.hh
+        - test -f $PREFIX/include/ninja/s_mat.hh
+        - test -f $PREFIX/include/ninja/spinors.hh
+        - test -f $PREFIX/include/ninja/static_arrays.hh
+        - test -f $PREFIX/include/ninja/tensor_ninja.hh
+        - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
+        - test -f $PREFIX/include/ninja/types.hh
+        - test -f $PREFIX/include/ninja/zero_float.hh
+        - test -f $PREFIX/include/ninjago_module.mod
+        - test -f $PREFIX/include/ninjavholo.mod
+        - test -f $PREFIX/include/quadninja/avholo.hh
+        - test -f $PREFIX/include/quadninja/integral_library.hh
+        - test -f $PREFIX/include/quadninja/looptools.hh
+        - test -f $PREFIX/include/quadninja/momentum.hh
+        - test -f $PREFIX/include/quadninja/ninja.hh
+        - test -f $PREFIX/include/quadninja/ninja_config.h
+        - test -f $PREFIX/include/quadninja/ninja_in.hh
+        - test -f $PREFIX/include/quadninja/ninjanumgen.hh
+        - test -f $PREFIX/include/quadninja/num_defs.hh
+        - test -f $PREFIX/include/quadninja/quadruple.hh
+        - test -f $PREFIX/include/quadninja/rambo.hh
+        - test -f $PREFIX/include/quadninja/s_mat.hh
+        - test -f $PREFIX/include/quadninja/spinors.hh
+        - test -f $PREFIX/include/quadninja/static_arrays.hh
+        - test -f $PREFIX/include/quadninja/tensor_ninja.hh
+        - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
+        - test -f $PREFIX/include/quadninja/types.hh
+        - test -f $PREFIX/include/quadninja/zero_float.hh
 
         - ninja-config --help
         - ninja-config --version
@@ -144,13 +162,11 @@ outputs:
         - make
         - pkg-config
         - gnuconfig
-        - oneloop  # [build_platform != target_platform]
+        - oneloop-static  # [build_platform != target_platform]
         - looptools-static  # [build_platform != target_platform]
       host:
-        - oneloop
+        - oneloop-static
         - looptools-static
-      run:
-        - oneloop
 
     test:
       # As need to regenerate Makefiles, need all of the source files that
@@ -167,34 +183,53 @@ outputs:
         - automake
         - libtool
         - make
-        # libooptools.a is needed at linktime, but not at runtime
+        # libooptools.a and libavh_olo.a are needed at linktime, but not at runtime
         - looptools-static
+        - oneloop-static
       commands:
         - test -f $PREFIX/lib/libninja.a
         # c.f. https://github.com/conda/conda-build/issues/3075
         - test ! -f $PREFIX/lib/libninja.la
         - test ! -f $PREFIX/lib/libninja${SHLIB_EXT}
-        - test -f $PREFIX/include/ninja/zero_float.hh
-        - test -f $PREFIX/include/ninja/types.hh
-        - test -f $PREFIX/include/ninja/tensor_ninja.hh
-        - test -f $PREFIX/include/ninja/ninja_in.hh
-        - test -f $PREFIX/include/ninja/ninja.hh
-        - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
-        - test -f $PREFIX/include/ninja/static_arrays.hh
-        - test -f $PREFIX/include/ninja/spinors.hh
-        - test -f $PREFIX/include/ninja/s_mat.hh
-        - test -f $PREFIX/include/ninja/rambo.hh
-        - test -f $PREFIX/include/ninja/num_defs.hh
-        - test -f $PREFIX/include/ninja/ninjanumgen.hh
-        - test -f $PREFIX/include/ninja/momentum.hh
-        - test -f $PREFIX/include/ninja/looptools.hh
-        - test -f $PREFIX/include/ninja/integral_library.hh
-        - test -f $PREFIX/include/ninja/avholo.hh
-        - test -f $PREFIX/include/ninja/ninja_config.h
-        - test -f $PREFIX/include/ninjavholo.mod
-        - test -f $PREFIX/include/ninjago_module.mod
-        - test -f $PREFIX/include/mninja.mod
         - test -f $PREFIX/bin/ninja-config
+        - test -f $PREFIX/include/mninja.mod
+        - test -f $PREFIX/include/ninja/avholo.hh
+        - test -f $PREFIX/include/ninja/integral_library.hh
+        - test -f $PREFIX/include/ninja/looptools.hh
+        - test -f $PREFIX/include/ninja/momentum.hh
+        - test -f $PREFIX/include/ninja/ninja.hh
+        - test -f $PREFIX/include/ninja/ninja_config.h
+        - test -f $PREFIX/include/ninja/ninja_in.hh
+        - test -f $PREFIX/include/ninja/ninjanumgen.hh
+        - test -f $PREFIX/include/ninja/num_defs.hh
+        - test -f $PREFIX/include/ninja/rambo.hh
+        - test -f $PREFIX/include/ninja/s_mat.hh
+        - test -f $PREFIX/include/ninja/spinors.hh
+        - test -f $PREFIX/include/ninja/static_arrays.hh
+        - test -f $PREFIX/include/ninja/tensor_ninja.hh
+        - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
+        - test -f $PREFIX/include/ninja/types.hh
+        - test -f $PREFIX/include/ninja/zero_float.hh
+        - test -f $PREFIX/include/ninjago_module.mod
+        - test -f $PREFIX/include/ninjavholo.mod
+        - test -f $PREFIX/include/quadninja/avholo.hh
+        - test -f $PREFIX/include/quadninja/integral_library.hh
+        - test -f $PREFIX/include/quadninja/looptools.hh
+        - test -f $PREFIX/include/quadninja/momentum.hh
+        - test -f $PREFIX/include/quadninja/ninja.hh
+        - test -f $PREFIX/include/quadninja/ninja_config.h
+        - test -f $PREFIX/include/quadninja/ninja_in.hh
+        - test -f $PREFIX/include/quadninja/ninjanumgen.hh
+        - test -f $PREFIX/include/quadninja/num_defs.hh
+        - test -f $PREFIX/include/quadninja/quadruple.hh
+        - test -f $PREFIX/include/quadninja/rambo.hh
+        - test -f $PREFIX/include/quadninja/s_mat.hh
+        - test -f $PREFIX/include/quadninja/spinors.hh
+        - test -f $PREFIX/include/quadninja/static_arrays.hh
+        - test -f $PREFIX/include/quadninja/tensor_ninja.hh
+        - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
+        - test -f $PREFIX/include/quadninja/types.hh
+        - test -f $PREFIX/include/quadninja/zero_float.hh
 
         - ninja-config --help
         - ninja-config --version


### PR DESCRIPTION
Resolves #3 

Amends PR https://github.com/conda-forge/ninja-hep-ph-feedstock/pull/2

* Use '--enable-quadninja' flag to enable quadninja.
   - Add quadninja includes to files tested for existence.
* Use oneloop-static for static library build output.
* Remove oneloop-static from run requirements for the static library build
  output as it is needed at linktime, but not runtime, as it is already
  linked into the ninja-hep-ph-static build output.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
