### PR TITLE
MNT: Explicilty enable higher_rank and NINJA_NO_EXCEPTIONS

### DIFF
--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -12,11 +12,14 @@ autoreconf --install
 # https://github.com/conda-forge/cfep/blob/main/cfep-18.md
 ./configure \
     --prefix=$PREFIX \
+    --enable-shared=yes \
     --enable-static=no \
-    --enable-quadninja=yes \
+    --enable-higher_rank \
+    --enable-quadninja \
     --with-avholo="$FFLAGS -lavh_olo" \
     --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
-    FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+    FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+    CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'
 make

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -10,11 +10,14 @@ autoreconf --install
 
 ./configure \
     --prefix=$PREFIX \
+    --enable-shared=no \
     --enable-static=yes \
-    --enable-quadninja=yes \
+    --enable-higher_rank \
+    --enable-quadninja \
     --with-avholo="$FFLAGS -lavh_olo" \
     --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
-    FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+    FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+    CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'
 make
@@ -25,6 +28,3 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR:
 fi
 make install
 make clean
-
-# Remove automatically built shared library
-rm $PREFIX/lib/libninja.so*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -115,7 +115,7 @@ outputs:
         # Given the way the examples/Makefile works, need to regenerate it and
         # other supporting files with configure again
         - autoreconf --install
-        - ./configure --prefix=$PREFIX --enable-static=no --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
         - make examples
 
         - cd examples
@@ -238,7 +238,7 @@ outputs:
         # Given the way the examples/Makefile works, need to regenerate it and
         # other supporting files with configure again
         - autoreconf --install
-        - ./configure --prefix=$PREFIX --enable-static=yes --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
         - make examples
 
         - cd examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - update-version-number-to-v1.2.0.patch
 
 build:
-  number: 3
+  number: 4
 
 outputs:
   - name: {{ name }}-hep-ph


### PR DESCRIPTION
* Explicitly add the options --enable-higher_rank and the C preprocessor definition NINJA_NO_EXCEPTIONS.
   - Set options given values in https://github.com/mg5amcnlo/HEPToolsInstallers/blob/d56fe6c04242360076be533a653c187493ef1187/installNinja.sh#L21
* Disable automatic build of shared libraries for static library build output.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
