### PR TITLE
ENH: Make quadninja optional and add macOS, aarch64 Linux builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,10 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,6 +11,9 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,0 +1,37 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: osx
+  pool:
+    vmImage: macOS-13
+  strategy:
+    matrix:
+      osx_64_:
+        CONFIG: osx_64_
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables: {}
+
+  steps:
+  # TODO: Fast finish on azure pipelines?
+  - script: |
+      export CI=azure
+      export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+      export remote_url=$(Build.Repository.Uri)
+      export sha=$(Build.SourceVersion)
+      export OSX_FORCE_SDK_DOWNLOAD="1"
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+        export IS_PR_BUILD="True"
+      else
+        export IS_PR_BUILD="False"
+      fi
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,25 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,0 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# -*- mode: jinja-shell -*-
+
+source .scripts/logging_utils.sh
+
+set -xe
+
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
+
+( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
+MICROMAMBA_VERSION="1.5.10-0"
+if [[ "$(uname -m)" == "arm64" ]]; then
+  osx_arch="osx-arm64"
+else
+  osx_arch="osx-64"
+fi
+MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
+MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
+echo "Downloading micromamba ${MICROMAMBA_VERSION}"
+micromamba_exe="$(mktemp -d)/micromamba"
+curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
+chmod +x "${micromamba_exe}"
+echo "Creating environment"
+"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
+  --channel conda-forge \
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
+mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
+echo "Cleaning up micromamba"
+rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
+( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
+
+( startgroup "Configuring conda" ) 2> /dev/null
+echo "Activating environment"
+source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
+conda activate base
+export CONDA_SOLVER="libmamba"
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
+
+
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+if [[ "${CI:-}" != "" ]]; then
+  mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+fi
+
+if [[ "${CI:-}" != "" ]]; then
+  echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+  /usr/bin/sudo mangle_homebrew
+  /usr/bin/sudo -k
+else
+  echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
+
+if [[ "${sha:-}" == "" ]]; then
+  sha=$(git rev-parse HEAD)
+fi
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+
+( endgroup "Configuring conda" ) 2> /dev/null
+
+echo -e "\n\nMaking the build clobber file"
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+if [[ -f LICENSE.txt ]]; then
+  cp LICENSE.txt "recipe/recipe-scripts-license.txt"
+fi
+
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+
+    # Drop into an interactive shell
+    /bin/bash
+else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
+    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
+        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir ./recipe -m ./.ci_support/${CONFIG}.yaml || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
+      upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
+fi

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ninja-hep-ph-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24224&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ninja-hep-ph-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24224&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ninja-hep-ph-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24224&branchName=main">
@@ -62,6 +69,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24224&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ninja-hep-ph-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24224&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ninja-hep-ph-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,3 +29,4 @@ stages:
   dependsOn: Check
   jobs:
     - template: ./.azure-pipelines/azure-pipelines-linux.yml
+    - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,11 +1,14 @@
-github:
-  branch_name: main
-  tooling_branch_name: main
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+  osx_arm64: osx_64
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
-build_platform:
-  linux_ppc64le: linux_64
+github:
+  branch_name: main
+  tooling_branch_name: main
 provider:
+  linux_aarch64: default
   linux_ppc64le: default
 test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
+bot:
+  abi_migration_branches:
+  - '1.x'
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -30,7 +30,7 @@ autoreconf --install
 # https://github.com/conda-forge/cfep/blob/main/cfep-18.md
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
-    if [[ "${target_platform}" == osx-arm64 ]]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
         ./configure \
             --prefix=$PREFIX \
             --enable-shared=yes \

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -2,12 +2,6 @@
 
 set -xe
 
-# FIXME: Unbreak builds for macOS using clang
-# c.f. https://github.com/peraro/ninja/issues/5
-if [[ -f VERSION ]]; then
-    rm VERSION
-fi
-
 export DISABLE_QUADMATH=false
 
 # libquadmath not supported on macOS or aarch64

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -27,16 +27,28 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
         export CXXFLAGS="-x c++ ${CXXFLAGS}"
     fi
-    ./configure \
-        --prefix=$PREFIX \
-        --enable-shared=yes \
-        --enable-static=no \
-        --enable-higher_rank \
-        --disable-quadninja \
-        --with-avholo="$FFLAGS -lavh_olo" \
-        --with-looptools="$FLDFLAGS -looptools -lgfortran" \
-        FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-        CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+    if [[ "${target_platform}" == osx-arm64 ]]; then
+        ./configure \
+            --prefix=$PREFIX \
+            --enable-shared=yes \
+            --enable-static=no \
+            --enable-higher_rank \
+            --disable-quadninja \
+            --with-avholo="$FFLAGS -lavh_olo" \
+            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+    else
+        ./configure \
+            --prefix=$PREFIX \
+            --enable-shared=yes \
+            --enable-static=no \
+            --enable-higher_rank \
+            --disable-quadninja \
+            --with-avholo="$FFLAGS -lavh_olo" \
+            --with-looptools="$FLDFLAGS -looptools -lgfortran" \
+            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+    fi
 else
     ./configure \
         --prefix=$PREFIX \

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -25,7 +25,9 @@ autoreconf --install
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
     if [[ "$(uname)" == "Darwin" ]]; then
-        export CXXFLAGS="-x c++ ${CXXFLAGS}"
+        # FIXME: Unbreak builds for macOS
+        # c.f. https://github.com/peraro/ninja/issues/5#issuecomment-2663059950
+        mv VERSION _VERSION
     fi
     if [[ "${target_platform}" == osx-arm64 ]]; then
         ./configure \
@@ -60,10 +62,6 @@ else
         --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
         FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
         CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
-fi
-
-if [[ "$(uname)" == "Darwin" ]]; then
-    cat Makefile
 fi
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+set -xe
+
+export DISABLE_QUADMATH=false
+
+# libquadmath not supported on macOS or aarch64
+if [[ "$(uname)" == "Darwin" ]]; then
+    export DISABLE_QUADMATH=true
+fi
+if [[ "${TARGET_PLATFORM}" == linux-aarch64 ]]; then
+    export DISABLE_QUADMATH=true
+fi
+
 # c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#cross-compilation-examples
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/gnuconfig/config.* .
@@ -10,16 +22,30 @@ autoreconf --install
 
 # Remove static library to comply with CFEP-18
 # https://github.com/conda-forge/cfep/blob/main/cfep-18.md
-./configure \
-    --prefix=$PREFIX \
-    --enable-shared=yes \
-    --enable-static=no \
-    --enable-higher_rank \
-    --enable-quadninja \
-    --with-avholo="$FFLAGS -lavh_olo" \
-    --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
-    FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-    CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+if [[ "${DISABLE_QUADMATH}" == true ]]; then
+    echo -e "\n# libquadmath not supported on target platform ${TARGET_PLATFORM} so disabling quadninja."
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-shared=yes \
+        --enable-static=no \
+        --enable-higher_rank \
+        --disable-quadninja \
+        --with-avholo="$FFLAGS -lavh_olo" \
+        --with-looptools="$FLDFLAGS -looptools -lgfortran" \
+        FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+        CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+else
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-shared=yes \
+        --enable-static=no \
+        --enable-higher_rank \
+        --enable-quadninja \
+        --with-avholo="$FFLAGS -lavh_olo" \
+        --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
+        FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+        CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+fi
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'
 make
@@ -30,3 +56,5 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR:
 fi
 make install
 make clean
+
+unset DISABLE_QUADMATH

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -24,7 +24,9 @@ autoreconf --install
 # https://github.com/conda-forge/cfep/blob/main/cfep-18.md
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
-    export CXXFLAGS="-x c++ ${CXXFLAGS}"  # [osx]
+    if [[ "$(uname)" == "Darwin" ]]; then
+        export CXXFLAGS="-x c++ ${CXXFLAGS}"
+    fi
     ./configure \
         --prefix=$PREFIX \
         --enable-shared=yes \
@@ -48,7 +50,9 @@ else
         CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
 fi
 
-cat Makefile  # [osx]
+if [[ "$(uname)" == "Darwin" ]]; then
+    cat Makefile
+fi
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'
 make

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -8,7 +8,7 @@ export DISABLE_QUADMATH=false
 if [[ "$(uname)" == "Darwin" ]]; then
     export DISABLE_QUADMATH=true
 fi
-if [[ "${TARGET_PLATFORM}" == linux-aarch64 ]]; then
+if [[ "${target_platform}" == linux-aarch64 ]]; then
     export DISABLE_QUADMATH=true
 fi
 
@@ -23,7 +23,7 @@ autoreconf --install
 # Remove static library to comply with CFEP-18
 # https://github.com/conda-forge/cfep/blob/main/cfep-18.md
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
-    echo -e "\n# libquadmath not supported on target platform ${TARGET_PLATFORM} so disabling quadninja."
+    echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
     ./configure \
         --prefix=$PREFIX \
         --enable-shared=yes \

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -7,6 +7,12 @@ export DISABLE_QUADMATH=false
 # libquadmath not supported on macOS or aarch64
 if [[ "$(uname)" == "Darwin" ]]; then
     export DISABLE_QUADMATH=true
+
+    # FIXME: Unbreak builds for macOS
+    # c.f. https://github.com/peraro/ninja/issues/5#issuecomment-2663059950
+    if [[ -f VERSION ]]; then
+        mv VERSION _VERSION
+    fi
 fi
 if [[ "${target_platform}" == linux-aarch64 ]]; then
     export DISABLE_QUADMATH=true
@@ -24,11 +30,6 @@ autoreconf --install
 # https://github.com/conda-forge/cfep/blob/main/cfep-18.md
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
-    if [[ "$(uname)" == "Darwin" ]]; then
-        # FIXME: Unbreak builds for macOS
-        # c.f. https://github.com/peraro/ninja/issues/5#issuecomment-2663059950
-        mv VERSION _VERSION
-    fi
     if [[ "${target_platform}" == osx-arm64 ]]; then
         ./configure \
             --prefix=$PREFIX \

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -24,6 +24,7 @@ autoreconf --install
 # https://github.com/conda-forge/cfep/blob/main/cfep-18.md
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
+    export CXXFLAGS="-x c++ ${CXXFLAGS}"  # [osx]
     ./configure \
         --prefix=$PREFIX \
         --enable-shared=yes \

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -2,17 +2,17 @@
 
 set -xe
 
+# FIXME: Unbreak builds for macOS using clang
+# c.f. https://github.com/peraro/ninja/issues/5
+if [[ -f VERSION ]]; then
+    rm VERSION
+fi
+
 export DISABLE_QUADMATH=false
 
 # libquadmath not supported on macOS or aarch64
 if [[ "$(uname)" == "Darwin" ]]; then
     export DISABLE_QUADMATH=true
-
-    # FIXME: Unbreak builds for macOS
-    # c.f. https://github.com/peraro/ninja/issues/5#issuecomment-2663059950
-    if [[ -f VERSION ]]; then
-        mv VERSION _VERSION
-    fi
 fi
 if [[ "${target_platform}" == linux-aarch64 ]]; then
     export DISABLE_QUADMATH=true

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -47,6 +47,8 @@ else
         CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
 fi
 
+cat Makefile  # [osx]
+
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'
 make
 

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -79,3 +79,11 @@ make install
 make clean
 
 unset DISABLE_QUADMATH
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    make examples
+
+    cd examples
+    echo -e "\n# simple_test"
+    ./simple_test
+fi

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -35,12 +35,12 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             --enable-shared=no \
             --enable-static=yes \
             --enable-higher_rank \
-            --disable-quadninja \
             --with-avholo="$FFLAGS -lavh_olo" \
             FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
             CXX="${CXX}" \
             CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" \
             CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" \
+            --disable-quadninja \
             LIBS="-lc++" \
             LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"
     else

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -22,7 +22,9 @@ autoreconf --install
 
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
-    export CXXFLAGS="-x c++ ${CXXFLAGS}"  # [osx]
+    if [[ "$(uname)" == "Darwin" ]]; then
+        export CXXFLAGS="-x c++ ${CXXFLAGS}"
+    fi
     ./configure \
         --prefix=$PREFIX \
         --enable-shared=no \
@@ -46,7 +48,9 @@ else
         CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
 fi
 
-cat Makefile  # [osx]
+if [[ "$(uname)" == "Darwin" ]]; then
+    cat Makefile
+fi
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'
 make

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -28,7 +28,7 @@ autoreconf --install
 
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
-    if [[ "${target_platform}" == osx-arm64 ]]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
         ./configure \
             --prefix=$PREFIX \
             --enable-shared=no \
@@ -37,32 +37,19 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             --disable-quadninja \
             --with-avholo="$FFLAGS -lavh_olo" \
             FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS" \
+            LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"
     else
-        if [[ "$(uname)" == "Darwin" ]]; then
-            ./configure \
-                --prefix=$PREFIX \
-                --enable-shared=no \
-                --enable-static=yes \
-                --enable-higher_rank \
-                --disable-quadninja \
-                --with-avholo="$FFLAGS -lavh_olo" \
-                --with-looptools="$FLDFLAGS -looptools -lgfortran" \
-                FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-                CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS" \
-                LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"
-        else
-            ./configure \
-                --prefix=$PREFIX \
-                --enable-shared=no \
-                --enable-static=yes \
-                --enable-higher_rank \
-                --disable-quadninja \
-                --with-avholo="$FFLAGS -lavh_olo" \
-                --with-looptools="$FLDFLAGS -looptools -lgfortran" \
-                FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-                CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
-        fi
+        ./configure \
+            --prefix=$PREFIX \
+            --enable-shared=no \
+            --enable-static=yes \
+            --enable-higher_rank \
+            --disable-quadninja \
+            --with-avholo="$FFLAGS -lavh_olo" \
+            --with-looptools="$FLDFLAGS -looptools -lgfortran" \
+            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
     fi
 else
     ./configure \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -39,16 +39,30 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
             CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
     else
-        ./configure \
-            --prefix=$PREFIX \
-            --enable-shared=no \
-            --enable-static=yes \
-            --enable-higher_rank \
-            --disable-quadninja \
-            --with-avholo="$FFLAGS -lavh_olo" \
-            --with-looptools="$FLDFLAGS -looptools -lgfortran" \
-            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+        if [[ "$(uname)" == "Darwin" ]]; then
+            ./configure \
+                --prefix=$PREFIX \
+                --enable-shared=no \
+                --enable-static=yes \
+                --enable-higher_rank \
+                --disable-quadninja \
+                --with-avholo="$FFLAGS -lavh_olo" \
+                --with-looptools="$FLDFLAGS -looptools -lgfortran" \
+                FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+                CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS" \
+                LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"
+        else
+            ./configure \
+                --prefix=$PREFIX \
+                --enable-shared=no \
+                --enable-static=yes \
+                --enable-higher_rank \
+                --disable-quadninja \
+                --with-avholo="$FFLAGS -lavh_olo" \
+                --with-looptools="$FLDFLAGS -looptools -lgfortran" \
+                FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+                CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+        fi
     fi
 else
     ./configure \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -25,16 +25,28 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
         export CXXFLAGS="-x c++ ${CXXFLAGS}"
     fi
-    ./configure \
-        --prefix=$PREFIX \
-        --enable-shared=no \
-        --enable-static=yes \
-        --enable-higher_rank \
-        --disable-quadninja \
-        --with-avholo="$FFLAGS -lavh_olo" \
-        --with-looptools="$FLDFLAGS -looptools -lgfortran" \
-        FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-        CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+    if [[ "${target_platform}" == osx-arm64 ]]; then
+        ./configure \
+            --prefix=$PREFIX \
+            --enable-shared=no \
+            --enable-static=yes \
+            --enable-higher_rank \
+            --disable-quadninja \
+            --with-avholo="$FFLAGS -lavh_olo" \
+            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+    else
+        ./configure \
+            --prefix=$PREFIX \
+            --enable-shared=no \
+            --enable-static=yes \
+            --enable-higher_rank \
+            --disable-quadninja \
+            --with-avholo="$FFLAGS -lavh_olo" \
+            --with-looptools="$FLDFLAGS -looptools -lgfortran" \
+            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+    fi
 else
     ./configure \
         --prefix=$PREFIX \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -28,7 +28,7 @@ autoreconf --install
 
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
-    if [[ "$(uname)" == "Darwin" ]]; then
+    if [[ "${target_platform}" == osx-arm64 ]]; then
         ./configure \
             --prefix=$PREFIX \
             --enable-shared=no \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -45,6 +45,8 @@ else
         CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
 fi
 
+cat Makefile  # [osx]
+
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'
 make
 

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -78,8 +78,3 @@ make install
 make clean
 
 unset DISABLE_QUADMATH
-
-# DEBUG
-if [[ "$(uname)" == "Darwin" ]]; then
-    make examples
-fi

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -2,12 +2,6 @@
 
 set -xe
 
-# FIXME: Unbreak builds for macOS using clang
-# c.f. https://github.com/peraro/ninja/issues/5
-if [[ -f VERSION ]]; then
-    rm VERSION
-fi
-
 export DISABLE_QUADMATH=false
 
 # libquadmath not supported on macOS or aarch64

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -35,12 +35,13 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             --enable-shared=no \
             --enable-static=yes \
             --enable-higher_rank \
-            --with-avholo="-L$PREFIX/lib -lavh_olo -lgfortran" \
-            FCINCLUDE="-I$PREFIX/include/oneloop" \
-            CXX="${CXX}" \
-            CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti" \
-            CPPFLAGS="-DNINJA_NO_EXCEPTIONS -fPIC" \
             --disable-quadninja \
+            --with-avholo="${FFLAGS} -lavh_olo -lgfortran" \
+            FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop" \
+            CXX="${CXX}" \
+            CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" \
+            CPPFLAGS="-DNINJA_NO_EXCEPTIONS -fPIC ${CPPFLAGS}" \
+            LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}" \
             LIBS="-lc++"
     else
         ./configure \
@@ -49,10 +50,12 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             --enable-static=yes \
             --enable-higher_rank \
             --disable-quadninja \
-            --with-avholo="$FFLAGS -lavh_olo" \
-            --with-looptools="$FLDFLAGS -looptools -lgfortran" \
-            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+            --with-avholo="${FFLAGS} -lavh_olo" \
+            --with-looptools="${FLDFLAGS} -looptools -lgfortran" \
+            FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop" \
+            CXXFLAGS="${CXXFLAGS}" \
+            CPPFLAGS="-DNINJA_NO_EXCEPTIONS -fPIC ${CPPFLAGS}" \
+            LDFLAGS="${LDFLAGS}"
     fi
 else
     ./configure \
@@ -61,10 +64,12 @@ else
         --enable-static=yes \
         --enable-higher_rank \
         --enable-quadninja \
-        --with-avholo="$FFLAGS -lavh_olo" \
-        --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
-        FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-        CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+        --with-avholo="${FFLAGS} -lavh_olo" \
+        --with-looptools="${FLDFLAGS} -looptools -lgfortran -lquadmath" \
+        FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop" \
+        CXXFLAGS="${CXXFLAGS}" \
+        CPPFLAGS="-DNINJA_NO_EXCEPTIONS -fPIC ${CPPFLAGS}" \
+        LDFLAGS="${LDFLAGS}"
 fi
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -39,8 +39,9 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             --with-avholo="$FFLAGS -lavh_olo" \
             FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
             CXX="${CXX}" \
-            CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" \
-            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS" \
+            CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" \
+            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" \
+            LIBS="-lc++" \
             LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"
     else
         ./configure \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -78,3 +78,8 @@ make install
 make clean
 
 unset DISABLE_QUADMATH
+
+# DEBUG
+if [[ "$(uname)" == "Darwin" ]]; then
+    make examples
+fi

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -22,6 +22,7 @@ autoreconf --install
 
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
+    export CXXFLAGS="-x c++ ${CXXFLAGS}"  # [osx]
     ./configure \
         --prefix=$PREFIX \
         --enable-shared=no \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -35,7 +35,7 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             --enable-shared=no \
             --enable-static=yes \
             --enable-higher_rank \
-            --with-avholo="-L$PREFIX/lib -lavh_olo" \
+            --with-avholo="-L$PREFIX/lib -lavh_olo -lgfortran" \
             FCINCLUDE="-I$PREFIX/include/oneloop" \
             CXX="${CXX}" \
             CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti" \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -8,7 +8,7 @@ export DISABLE_QUADMATH=false
 if [[ "$(uname)" == "Darwin" ]]; then
     export DISABLE_QUADMATH=true
 fi
-if [[ "${TARGET_PLATFORM}" == linux-aarch64 ]]; then
+if [[ "${target_platform}" == linux-aarch64 ]]; then
     export DISABLE_QUADMATH=true
 fi
 
@@ -21,7 +21,7 @@ autoreconf --install
 ./configure --help
 
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
-    echo -e "\n# libquadmath not supported on target platform ${TARGET_PLATFORM} so disabling quadninja."
+    echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
     ./configure \
         --prefix=$PREFIX \
         --enable-shared=no \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -35,14 +35,13 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             --enable-shared=no \
             --enable-static=yes \
             --enable-higher_rank \
-            --with-avholo="$FFLAGS -lavh_olo" \
-            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+            --with-avholo="-L$PREFIX/lib -lavh_olo" \
+            FCINCLUDE="-I$PREFIX/include/oneloop" \
             CXX="${CXX}" \
-            CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" \
-            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" \
+            CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti" \
+            CPPFLAGS="-DNINJA_NO_EXCEPTIONS -fPIC" \
             --disable-quadninja \
-            LIBS="-lc++" \
-            LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"
+            LIBS="-lc++"
     else
         ./configure \
             --prefix=$PREFIX \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -7,6 +7,12 @@ export DISABLE_QUADMATH=false
 # libquadmath not supported on macOS or aarch64
 if [[ "$(uname)" == "Darwin" ]]; then
     export DISABLE_QUADMATH=true
+
+    # FIXME: Unbreak builds for macOS
+    # c.f. https://github.com/peraro/ninja/issues/5#issuecomment-2663059950
+    if [[ -f VERSION ]]; then
+        mv VERSION _VERSION
+    fi
 fi
 if [[ "${target_platform}" == linux-aarch64 ]]; then
     export DISABLE_QUADMATH=true
@@ -22,11 +28,6 @@ autoreconf --install
 
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
-    if [[ "$(uname)" == "Darwin" ]]; then
-        # FIXME: Unbreak builds for macOS
-        # c.f. https://github.com/peraro/ninja/issues/5#issuecomment-2663059950
-        mv VERSION _VERSION
-    fi
     if [[ "${target_platform}" == osx-arm64 ]]; then
         ./configure \
             --prefix=$PREFIX \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -39,7 +39,7 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             --with-avholo="$FFLAGS -lavh_olo" \
             FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
             CXX="${CXX}" \
-            CXXFLAGS="${CXXFLAGS}" \
+            CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" \
             CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS" \
             LIBS="-lstdc++" \
             LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -78,11 +78,3 @@ make install
 make clean
 
 unset DISABLE_QUADMATH
-
-if [[ "$(uname)" == "Darwin" ]]; then
-    make examples
-
-    cd examples
-    echo -e "\n# simple_test"
-    ./simple_test
-fi

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -23,7 +23,9 @@ autoreconf --install
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
     if [[ "$(uname)" == "Darwin" ]]; then
-        export CXXFLAGS="-x c++ ${CXXFLAGS}"
+        # FIXME: Unbreak builds for macOS
+        # c.f. https://github.com/peraro/ninja/issues/5#issuecomment-2663059950
+        mv VERSION _VERSION
     fi
     if [[ "${target_platform}" == osx-arm64 ]]; then
         ./configure \
@@ -58,10 +60,6 @@ else
         --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
         FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
         CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
-fi
-
-if [[ "$(uname)" == "Darwin" ]]; then
-    cat Makefile
 fi
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -28,7 +28,7 @@ autoreconf --install
 
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
-    if [[ "${target_platform}" == osx-arm64 ]]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
         ./configure \
             --prefix=$PREFIX \
             --enable-shared=no \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -41,7 +41,6 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             CXX="${CXX}" \
             CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" \
             CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS" \
-            LIBS="-lstdc++" \
             LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"
     else
         ./configure \

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -2,17 +2,17 @@
 
 set -xe
 
+# FIXME: Unbreak builds for macOS using clang
+# c.f. https://github.com/peraro/ninja/issues/5
+if [[ -f VERSION ]]; then
+    rm VERSION
+fi
+
 export DISABLE_QUADMATH=false
 
 # libquadmath not supported on macOS or aarch64
 if [[ "$(uname)" == "Darwin" ]]; then
     export DISABLE_QUADMATH=true
-
-    # FIXME: Unbreak builds for macOS
-    # c.f. https://github.com/peraro/ninja/issues/5#issuecomment-2663059950
-    if [[ -f VERSION ]]; then
-        mv VERSION _VERSION
-    fi
 fi
 if [[ "${target_platform}" == linux-aarch64 ]]; then
     export DISABLE_QUADMATH=true

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -29,6 +29,7 @@ autoreconf --install
 if [[ "${DISABLE_QUADMATH}" == true ]]; then
     echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
     if [[ "$(uname)" == "Darwin" ]]; then
+        # Following https://github.com/mg5amcnlo/HEPToolsInstallers/blob/d56fe6c04242360076be533a653c187493ef1187/installNinja.sh#L18-L19
         ./configure \
             --prefix=$PREFIX \
             --enable-shared=no \
@@ -37,7 +38,10 @@ if [[ "${DISABLE_QUADMATH}" == true ]]; then
             --disable-quadninja \
             --with-avholo="$FFLAGS -lavh_olo" \
             FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+            CXX="${CXX}" \
+            CXXFLAGS="${CXXFLAGS}" \
             CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS" \
+            LIBS="-lstdc++" \
             LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"
     else
         ./configure \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -133,6 +133,7 @@ outputs:
         # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
         # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
         - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
+        - grep exninjastatic configure.ac  # [osx]
 
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
@@ -308,6 +309,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
       {% else %}
+        - grep exninjastatic configure.ac  # [osx]
+
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
       {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
   patches:
     - posix-compliant-shell.patch
     - update-version-number-to-v1.2.0.patch
+    # c.f. https://github.com/peraro/ninja/issues/5
+    - remove-version-file.patch
 
 build:
   number: 5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -276,7 +276,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx and x86_64]
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
       {% endif %}
         - make examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,158 +18,158 @@ build:
   number: 5
 
 outputs:
-  - name: {{ name }}-hep-ph
+  # - name: {{ name }}-hep-ph
 
-    script: build_shared.sh
+  #   script: build_shared.sh
 
-    build:
-      skip: true  # [win]
-      run_exports:
-        - {{ pin_subpackage('ninja-hep-ph', max_pin='x.x') }}
+  #   build:
+  #     skip: true  # [win]
+  #     run_exports:
+  #       - {{ pin_subpackage('ninja-hep-ph', max_pin='x.x') }}
 
-    requirements:
-      build:
-        - {{ stdlib('c') }}
-        - {{ compiler('cxx') }}
-        - {{ compiler('fortran') }}
-        - automake  # includes autoconf
-        - libtool
-        - make
-        - pkg-config
-        - gnuconfig
-        - gawk
-        - sed
-        - grep
-        - oneloop  # [build_platform != target_platform]
-        # FIXME: Add looptools for osx-arm64
-        - looptools-static  # [(build_platform != target_platform) and (not osx)]
-      host:
-        - oneloop
-        - looptools-static  # [not osx]
-      run:
-        - oneloop
+  #   requirements:
+  #     build:
+  #       - {{ stdlib('c') }}
+  #       - {{ compiler('cxx') }}
+  #       - {{ compiler('fortran') }}
+  #       - automake  # includes autoconf
+  #       - libtool
+  #       - make
+  #       - pkg-config
+  #       - gnuconfig
+  #       - gawk
+  #       - sed
+  #       - grep
+  #       - oneloop  # [build_platform != target_platform]
+  #       # FIXME: Add looptools for osx-arm64
+  #       - looptools-static  # [(build_platform != target_platform) and (not osx)]
+  #     host:
+  #       - oneloop
+  #       - looptools-static  # [not osx]
+  #     run:
+  #       - oneloop
 
-    test:
-      # As need to regenerate Makefiles, need all of the source files that
-      # configure uses to do so
-      source_files:
-        - examples/
-        - m4/
-        - src/
-        - Makefile.am
-        - configure.ac
-      requires:
-        - {{ compiler('cxx') }}
-        - {{ compiler('fortran') }}
-        - automake
-        - libtool
-        - make
-        - gawk
-        - sed
-        - grep
-        # libooptools.a is needed at linktime, but not at runtime
-        - looptools-static  # [not osx]
-      commands:
-        - test -f $PREFIX/lib/libninja${SHLIB_EXT}
-        # c.f. https://github.com/conda/conda-build/issues/3075
-        - test ! -f $PREFIX/lib/libninja.la
-        - test ! -f $PREFIX/lib/libninja.a
-        - test -f $PREFIX/bin/ninja-config
-        - test -f $PREFIX/include/mninja.mod
-        - test -f $PREFIX/include/ninja/avholo.hh
-        - test -f $PREFIX/include/ninja/integral_library.hh
-        - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
-        - test -f $PREFIX/include/ninja/momentum.hh
-        - test -f $PREFIX/include/ninja/ninja.hh
-        - test -f $PREFIX/include/ninja/ninja_config.h
-        - test -f $PREFIX/include/ninja/ninja_in.hh
-        - test -f $PREFIX/include/ninja/ninjanumgen.hh
-        - test -f $PREFIX/include/ninja/num_defs.hh
-        - test -f $PREFIX/include/ninja/rambo.hh
-        - test -f $PREFIX/include/ninja/s_mat.hh
-        - test -f $PREFIX/include/ninja/spinors.hh
-        - test -f $PREFIX/include/ninja/static_arrays.hh
-        - test -f $PREFIX/include/ninja/tensor_ninja.hh
-        - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
-        - test -f $PREFIX/include/ninja/types.hh
-        - test -f $PREFIX/include/ninja/zero_float.hh
-        - test -f $PREFIX/include/ninjago_module.mod
-        - test -f $PREFIX/include/ninjavholo.mod
-      {% if (linux and (x86_64 or ppc64le)) %}
-        - test -f $PREFIX/include/quadninja/avholo.hh
-        - test -f $PREFIX/include/quadninja/integral_library.hh
-        - test -f $PREFIX/include/quadninja/looptools.hh
-        - test -f $PREFIX/include/quadninja/momentum.hh
-        - test -f $PREFIX/include/quadninja/ninja.hh
-        - test -f $PREFIX/include/quadninja/ninja_config.h
-        - test -f $PREFIX/include/quadninja/ninja_in.hh
-        - test -f $PREFIX/include/quadninja/ninjanumgen.hh
-        - test -f $PREFIX/include/quadninja/num_defs.hh
-        - test -f $PREFIX/include/quadninja/quadruple.hh
-        - test -f $PREFIX/include/quadninja/rambo.hh
-        - test -f $PREFIX/include/quadninja/s_mat.hh
-        - test -f $PREFIX/include/quadninja/spinors.hh
-        - test -f $PREFIX/include/quadninja/static_arrays.hh
-        - test -f $PREFIX/include/quadninja/tensor_ninja.hh
-        - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
-        - test -f $PREFIX/include/quadninja/types.hh
-        - test -f $PREFIX/include/quadninja/zero_float.hh
-      {% else %}
-        - test ! -d $PREFIX/include/quadninja
-      {% endif %}
+  #   test:
+  #     # As need to regenerate Makefiles, need all of the source files that
+  #     # configure uses to do so
+  #     source_files:
+  #       - examples/
+  #       - m4/
+  #       - src/
+  #       - Makefile.am
+  #       - configure.ac
+  #     requires:
+  #       - {{ compiler('cxx') }}
+  #       - {{ compiler('fortran') }}
+  #       - automake
+  #       - libtool
+  #       - make
+  #       - gawk
+  #       - sed
+  #       - grep
+  #       # libooptools.a is needed at linktime, but not at runtime
+  #       - looptools-static  # [not osx]
+  #     commands:
+  #       - test -f $PREFIX/lib/libninja${SHLIB_EXT}
+  #       # c.f. https://github.com/conda/conda-build/issues/3075
+  #       - test ! -f $PREFIX/lib/libninja.la
+  #       - test ! -f $PREFIX/lib/libninja.a
+  #       - test -f $PREFIX/bin/ninja-config
+  #       - test -f $PREFIX/include/mninja.mod
+  #       - test -f $PREFIX/include/ninja/avholo.hh
+  #       - test -f $PREFIX/include/ninja/integral_library.hh
+  #       - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
+  #       - test -f $PREFIX/include/ninja/momentum.hh
+  #       - test -f $PREFIX/include/ninja/ninja.hh
+  #       - test -f $PREFIX/include/ninja/ninja_config.h
+  #       - test -f $PREFIX/include/ninja/ninja_in.hh
+  #       - test -f $PREFIX/include/ninja/ninjanumgen.hh
+  #       - test -f $PREFIX/include/ninja/num_defs.hh
+  #       - test -f $PREFIX/include/ninja/rambo.hh
+  #       - test -f $PREFIX/include/ninja/s_mat.hh
+  #       - test -f $PREFIX/include/ninja/spinors.hh
+  #       - test -f $PREFIX/include/ninja/static_arrays.hh
+  #       - test -f $PREFIX/include/ninja/tensor_ninja.hh
+  #       - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
+  #       - test -f $PREFIX/include/ninja/types.hh
+  #       - test -f $PREFIX/include/ninja/zero_float.hh
+  #       - test -f $PREFIX/include/ninjago_module.mod
+  #       - test -f $PREFIX/include/ninjavholo.mod
+  #     {% if (linux and (x86_64 or ppc64le)) %}
+  #       - test -f $PREFIX/include/quadninja/avholo.hh
+  #       - test -f $PREFIX/include/quadninja/integral_library.hh
+  #       - test -f $PREFIX/include/quadninja/looptools.hh
+  #       - test -f $PREFIX/include/quadninja/momentum.hh
+  #       - test -f $PREFIX/include/quadninja/ninja.hh
+  #       - test -f $PREFIX/include/quadninja/ninja_config.h
+  #       - test -f $PREFIX/include/quadninja/ninja_in.hh
+  #       - test -f $PREFIX/include/quadninja/ninjanumgen.hh
+  #       - test -f $PREFIX/include/quadninja/num_defs.hh
+  #       - test -f $PREFIX/include/quadninja/quadruple.hh
+  #       - test -f $PREFIX/include/quadninja/rambo.hh
+  #       - test -f $PREFIX/include/quadninja/s_mat.hh
+  #       - test -f $PREFIX/include/quadninja/spinors.hh
+  #       - test -f $PREFIX/include/quadninja/static_arrays.hh
+  #       - test -f $PREFIX/include/quadninja/tensor_ninja.hh
+  #       - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
+  #       - test -f $PREFIX/include/quadninja/types.hh
+  #       - test -f $PREFIX/include/quadninja/zero_float.hh
+  #     {% else %}
+  #       - test ! -d $PREFIX/include/quadninja
+  #     {% endif %}
 
-        - ninja-config --help
-        - ninja-config --version
-        - ninja-config --quadsupport
+  #       - ninja-config --help
+  #       - ninja-config --version
+  #       - ninja-config --quadsupport
 
-        # Given the way the examples/Makefile works, need to regenerate it and
-        # other supporting files with configure again
-        - autoreconf --install
+  #       # Given the way the examples/Makefile works, need to regenerate it and
+  #       # other supporting files with configure again
+  #       - autoreconf --install
 
-      {% if (linux and (x86_64 or ppc64le)) %}
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
-      {% else %}
-        # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
-        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
-        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
-        - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
+  #     {% if (linux and (x86_64 or ppc64le)) %}
+  #       - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+  #     {% else %}
+  #       # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
+  #       # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
+  #       # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
+  #       - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
 
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]  # [osx]
-      {% endif %}
-        - make clean
-        - make examples
+  #       - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
+  #       - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]  # [osx]
+  #     {% endif %}
+  #       - make clean
+  #       - make examples
 
-        - cd examples
-        - echo -e "\n# simple_test"
-        - ./simple_test
-        - echo -e "\n# simple_higher_rank_test"
-        - ./simple_higher_rank_test
-        - echo -e "\n# tensor_test"
-        - ./tensor_test
-        - echo -e "\n# tensor_higher_rank_test"
-        - ./tensor_higher_rank_test
-        - echo -e "\n# 4photons"
-        - ./4photons
-        - echo -e "\n# 6photons"
-        - ./6photons
-        - echo -e "\n# ttbarh"
-        - ./ttbarh
+  #       - cd examples
+  #       - echo -e "\n# simple_test"
+  #       - ./simple_test
+  #       - echo -e "\n# simple_higher_rank_test"
+  #       - ./simple_higher_rank_test
+  #       - echo -e "\n# tensor_test"
+  #       - ./tensor_test
+  #       - echo -e "\n# tensor_higher_rank_test"
+  #       - ./tensor_higher_rank_test
+  #       - echo -e "\n# 4photons"
+  #       - ./4photons
+  #       - echo -e "\n# 6photons"
+  #       - ./6photons
+  #       - echo -e "\n# ttbarh"
+  #       - ./ttbarh
 
-        # Show how to build manually
-        - make clean
-        - echo -e "\n# simple_test by hand"
-      {% if (linux and (x86_64 or ppc64le)) %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
-      {% else %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
-      {% endif %}
-        - ./simple_test
+  #       # Show how to build manually
+  #       - make clean
+  #       - echo -e "\n# simple_test by hand"
+  #     {% if (linux and (x86_64 or ppc64le)) %}
+  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
+  #     {% else %}
+  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
+  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
+  #     {% endif %}
+  #       - ./simple_test
 
-        - make clean
-        - cd ..
-        - make clean
+  #       - make clean
+  #       - cd ..
+  #       - make clean
 
   - name: {{ name }}-hep-ph-static
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,6 +135,7 @@ outputs:
         - make examples
 
         - cd examples
+        - otool -L simple_test  # [osx]
         - echo -e "\n# simple_test"
         - ./simple_test
         - echo -e "\n# simple_higher_rank_test"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -280,7 +280,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
         - make clean
         - make examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -277,10 +277,10 @@ outputs:
         # other supporting files with configure again
         - autoreconf --install
       {% if (linux and (x86_64 or ppc64le)) %}
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="${FFLAGS} -lavh_olo" --with-looptools="${FLDFLAGS} -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop"
       {% else %}
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="${FFLAGS} -lavh_olo" --with-looptools="${FLDFLAGS} -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop"  # [not osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="${FFLAGS} -lavh_olo -lgfortran" FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
         - make clean
         - make examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - update-version-number-to-v1.2.0.patch
 
 build:
-  number: 4
+  number: 5
 
 outputs:
   - name: {{ name }}-hep-ph
@@ -23,8 +23,7 @@ outputs:
     script: build_shared.sh
 
     build:
-      # libquadmath is required, so macOS is not supported
-      skip: true  # [not linux]
+      skip: true  # [win]
       run_exports:
         - {{ pin_subpackage('ninja-hep-ph', max_pin='x.x') }}
 
@@ -89,6 +88,7 @@ outputs:
         - test -f $PREFIX/include/ninja/zero_float.hh
         - test -f $PREFIX/include/ninjago_module.mod
         - test -f $PREFIX/include/ninjavholo.mod
+      {% if (linux and (x86_64 or ppc64le)) %}
         - test -f $PREFIX/include/quadninja/avholo.hh
         - test -f $PREFIX/include/quadninja/integral_library.hh
         - test -f $PREFIX/include/quadninja/looptools.hh
@@ -107,6 +107,9 @@ outputs:
         - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
         - test -f $PREFIX/include/quadninja/types.hh
         - test -f $PREFIX/include/quadninja/zero_float.hh
+      {% else %}
+        - test ! -d $PREFIX/include/quadninja
+      {% endif %}
 
         - ninja-config --help
         - ninja-config --version
@@ -115,7 +118,12 @@ outputs:
         # Given the way the examples/Makefile works, need to regenerate it and
         # other supporting files with configure again
         - autoreconf --install
+
+      {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+      {% else %}
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+      {% endif %}
         - make examples
 
         - cd examples
@@ -137,7 +145,11 @@ outputs:
         # Show how to build manually
         - make clean
         - echo -e "\n# simple_test by hand"
+      {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
+      {% else %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran
+      {% endif %}
         - ./simple_test
 
         - make clean
@@ -149,8 +161,7 @@ outputs:
     script: build_static.sh
 
     build:
-      # libquadmath is required, so macOS is not supported
-      skip: true  # [not linux]
+      skip: true  # [win]
 
     requirements:
       build:
@@ -212,6 +223,7 @@ outputs:
         - test -f $PREFIX/include/ninja/zero_float.hh
         - test -f $PREFIX/include/ninjago_module.mod
         - test -f $PREFIX/include/ninjavholo.mod
+      {% if (linux and (x86_64 or ppc64le)) %}
         - test -f $PREFIX/include/quadninja/avholo.hh
         - test -f $PREFIX/include/quadninja/integral_library.hh
         - test -f $PREFIX/include/quadninja/looptools.hh
@@ -230,6 +242,9 @@ outputs:
         - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
         - test -f $PREFIX/include/quadninja/types.hh
         - test -f $PREFIX/include/quadninja/zero_float.hh
+      {% else %}
+        - test ! -d $PREFIX/include/quadninja
+      {% endif %}
 
         - ninja-config --help
         - ninja-config --version
@@ -238,7 +253,11 @@ outputs:
         # Given the way the examples/Makefile works, need to regenerate it and
         # other supporting files with configure again
         - autoreconf --install
+      {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+      {% else %}
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+      {% endif %}
         - make examples
 
         - cd examples
@@ -260,7 +279,12 @@ outputs:
         # Show how to build manually
         - make clean
         - echo -e "\n# simple_test by hand"
+
+      {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
+      {% else %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran
+      {% endif %}
         - ./simple_test
 
         - make clean

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -280,7 +280,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
         - make clean
         - make examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,11 +129,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
-        # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
-        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
-        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]  # linux-aarch64
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
       {% endif %}
         - make examples
 
@@ -163,11 +160,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
       {% else %}
-        # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
-        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
-        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]  # linux-aarch64
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
       {% endif %}
         - ./simple_test
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -166,8 +166,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
       {% else %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
       {% endif %}
         - ./simple_test
 
@@ -309,10 +309,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
       {% else %}
-        - grep exninjastatic configure.ac  # [osx]
-
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
       {% endif %}
         - ./simple_test
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -211,6 +211,8 @@ outputs:
         - automake
         - libtool
         - make
+        - pkg-config
+        - gnuconfig
         - gawk
         - sed
         - grep
@@ -272,6 +274,7 @@ outputs:
 
         # Given the way the examples/Makefile works, need to regenerate it and
         # other supporting files with configure again
+        - cp $BUILD_PREFIX/share/gnuconfig/config.* .
         - autoreconf --install
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,158 +18,158 @@ build:
   number: 5
 
 outputs:
-  # - name: {{ name }}-hep-ph
+  - name: {{ name }}-hep-ph
 
-  #   script: build_shared.sh
+    script: build_shared.sh
 
-  #   build:
-  #     skip: true  # [win]
-  #     run_exports:
-  #       - {{ pin_subpackage('ninja-hep-ph', max_pin='x.x') }}
+    build:
+      skip: true  # [win]
+      run_exports:
+        - {{ pin_subpackage('ninja-hep-ph', max_pin='x.x') }}
 
-  #   requirements:
-  #     build:
-  #       - {{ stdlib('c') }}
-  #       - {{ compiler('cxx') }}
-  #       - {{ compiler('fortran') }}
-  #       - automake  # includes autoconf
-  #       - libtool
-  #       - make
-  #       - pkg-config
-  #       - gnuconfig
-  #       - gawk
-  #       - sed
-  #       - grep
-  #       - oneloop  # [build_platform != target_platform]
-  #       # FIXME: Add looptools for osx-arm64
-  #       - looptools-static  # [(build_platform != target_platform) and (not osx)]
-  #     host:
-  #       - oneloop
-  #       - looptools-static  # [not osx]
-  #     run:
-  #       - oneloop
+    requirements:
+      build:
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}
+        - {{ compiler('fortran') }}
+        - automake  # includes autoconf
+        - libtool
+        - make
+        - pkg-config
+        - gnuconfig
+        - gawk
+        - sed
+        - grep
+        - oneloop  # [build_platform != target_platform]
+        # FIXME: Add looptools for osx-arm64
+        - looptools-static  # [(build_platform != target_platform) and (not osx)]
+      host:
+        - oneloop
+        - looptools-static  # [not osx]
+      run:
+        - oneloop
 
-  #   test:
-  #     # As need to regenerate Makefiles, need all of the source files that
-  #     # configure uses to do so
-  #     source_files:
-  #       - examples/
-  #       - m4/
-  #       - src/
-  #       - Makefile.am
-  #       - configure.ac
-  #     requires:
-  #       - {{ compiler('cxx') }}
-  #       - {{ compiler('fortran') }}
-  #       - automake
-  #       - libtool
-  #       - make
-  #       - gawk
-  #       - sed
-  #       - grep
-  #       # libooptools.a is needed at linktime, but not at runtime
-  #       - looptools-static  # [not osx]
-  #     commands:
-  #       - test -f $PREFIX/lib/libninja${SHLIB_EXT}
-  #       # c.f. https://github.com/conda/conda-build/issues/3075
-  #       - test ! -f $PREFIX/lib/libninja.la
-  #       - test ! -f $PREFIX/lib/libninja.a
-  #       - test -f $PREFIX/bin/ninja-config
-  #       - test -f $PREFIX/include/mninja.mod
-  #       - test -f $PREFIX/include/ninja/avholo.hh
-  #       - test -f $PREFIX/include/ninja/integral_library.hh
-  #       - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
-  #       - test -f $PREFIX/include/ninja/momentum.hh
-  #       - test -f $PREFIX/include/ninja/ninja.hh
-  #       - test -f $PREFIX/include/ninja/ninja_config.h
-  #       - test -f $PREFIX/include/ninja/ninja_in.hh
-  #       - test -f $PREFIX/include/ninja/ninjanumgen.hh
-  #       - test -f $PREFIX/include/ninja/num_defs.hh
-  #       - test -f $PREFIX/include/ninja/rambo.hh
-  #       - test -f $PREFIX/include/ninja/s_mat.hh
-  #       - test -f $PREFIX/include/ninja/spinors.hh
-  #       - test -f $PREFIX/include/ninja/static_arrays.hh
-  #       - test -f $PREFIX/include/ninja/tensor_ninja.hh
-  #       - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
-  #       - test -f $PREFIX/include/ninja/types.hh
-  #       - test -f $PREFIX/include/ninja/zero_float.hh
-  #       - test -f $PREFIX/include/ninjago_module.mod
-  #       - test -f $PREFIX/include/ninjavholo.mod
-  #     {% if (linux and (x86_64 or ppc64le)) %}
-  #       - test -f $PREFIX/include/quadninja/avholo.hh
-  #       - test -f $PREFIX/include/quadninja/integral_library.hh
-  #       - test -f $PREFIX/include/quadninja/looptools.hh
-  #       - test -f $PREFIX/include/quadninja/momentum.hh
-  #       - test -f $PREFIX/include/quadninja/ninja.hh
-  #       - test -f $PREFIX/include/quadninja/ninja_config.h
-  #       - test -f $PREFIX/include/quadninja/ninja_in.hh
-  #       - test -f $PREFIX/include/quadninja/ninjanumgen.hh
-  #       - test -f $PREFIX/include/quadninja/num_defs.hh
-  #       - test -f $PREFIX/include/quadninja/quadruple.hh
-  #       - test -f $PREFIX/include/quadninja/rambo.hh
-  #       - test -f $PREFIX/include/quadninja/s_mat.hh
-  #       - test -f $PREFIX/include/quadninja/spinors.hh
-  #       - test -f $PREFIX/include/quadninja/static_arrays.hh
-  #       - test -f $PREFIX/include/quadninja/tensor_ninja.hh
-  #       - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
-  #       - test -f $PREFIX/include/quadninja/types.hh
-  #       - test -f $PREFIX/include/quadninja/zero_float.hh
-  #     {% else %}
-  #       - test ! -d $PREFIX/include/quadninja
-  #     {% endif %}
+    test:
+      # As need to regenerate Makefiles, need all of the source files that
+      # configure uses to do so
+      source_files:
+        - examples/
+        - m4/
+        - src/
+        - Makefile.am
+        - configure.ac
+      requires:
+        - {{ compiler('cxx') }}
+        - {{ compiler('fortran') }}
+        - automake
+        - libtool
+        - make
+        - gawk
+        - sed
+        - grep
+        # libooptools.a is needed at linktime, but not at runtime
+        - looptools-static  # [not osx]
+      commands:
+        - test -f $PREFIX/lib/libninja${SHLIB_EXT}
+        # c.f. https://github.com/conda/conda-build/issues/3075
+        - test ! -f $PREFIX/lib/libninja.la
+        - test ! -f $PREFIX/lib/libninja.a
+        - test -f $PREFIX/bin/ninja-config
+        - test -f $PREFIX/include/mninja.mod
+        - test -f $PREFIX/include/ninja/avholo.hh
+        - test -f $PREFIX/include/ninja/integral_library.hh
+        - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
+        - test -f $PREFIX/include/ninja/momentum.hh
+        - test -f $PREFIX/include/ninja/ninja.hh
+        - test -f $PREFIX/include/ninja/ninja_config.h
+        - test -f $PREFIX/include/ninja/ninja_in.hh
+        - test -f $PREFIX/include/ninja/ninjanumgen.hh
+        - test -f $PREFIX/include/ninja/num_defs.hh
+        - test -f $PREFIX/include/ninja/rambo.hh
+        - test -f $PREFIX/include/ninja/s_mat.hh
+        - test -f $PREFIX/include/ninja/spinors.hh
+        - test -f $PREFIX/include/ninja/static_arrays.hh
+        - test -f $PREFIX/include/ninja/tensor_ninja.hh
+        - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
+        - test -f $PREFIX/include/ninja/types.hh
+        - test -f $PREFIX/include/ninja/zero_float.hh
+        - test -f $PREFIX/include/ninjago_module.mod
+        - test -f $PREFIX/include/ninjavholo.mod
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - test -f $PREFIX/include/quadninja/avholo.hh
+        - test -f $PREFIX/include/quadninja/integral_library.hh
+        - test -f $PREFIX/include/quadninja/looptools.hh
+        - test -f $PREFIX/include/quadninja/momentum.hh
+        - test -f $PREFIX/include/quadninja/ninja.hh
+        - test -f $PREFIX/include/quadninja/ninja_config.h
+        - test -f $PREFIX/include/quadninja/ninja_in.hh
+        - test -f $PREFIX/include/quadninja/ninjanumgen.hh
+        - test -f $PREFIX/include/quadninja/num_defs.hh
+        - test -f $PREFIX/include/quadninja/quadruple.hh
+        - test -f $PREFIX/include/quadninja/rambo.hh
+        - test -f $PREFIX/include/quadninja/s_mat.hh
+        - test -f $PREFIX/include/quadninja/spinors.hh
+        - test -f $PREFIX/include/quadninja/static_arrays.hh
+        - test -f $PREFIX/include/quadninja/tensor_ninja.hh
+        - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
+        - test -f $PREFIX/include/quadninja/types.hh
+        - test -f $PREFIX/include/quadninja/zero_float.hh
+      {% else %}
+        - test ! -d $PREFIX/include/quadninja
+      {% endif %}
 
-  #       - ninja-config --help
-  #       - ninja-config --version
-  #       - ninja-config --quadsupport
+        - ninja-config --help
+        - ninja-config --version
+        - ninja-config --quadsupport
 
-  #       # Given the way the examples/Makefile works, need to regenerate it and
-  #       # other supporting files with configure again
-  #       - autoreconf --install
+        # Given the way the examples/Makefile works, need to regenerate it and
+        # other supporting files with configure again
+        - autoreconf --install
 
-  #     {% if (linux and (x86_64 or ppc64le)) %}
-  #       - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
-  #     {% else %}
-  #       # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
-  #       # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
-  #       # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
-  #       - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+      {% else %}
+        # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
+        - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
 
-  #       - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-  #       - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]  # [osx]
-  #     {% endif %}
-  #       - make clean
-  #       - make examples
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]  # [osx]
+      {% endif %}
+        - make clean
+        - make examples
 
-  #       - cd examples
-  #       - echo -e "\n# simple_test"
-  #       - ./simple_test
-  #       - echo -e "\n# simple_higher_rank_test"
-  #       - ./simple_higher_rank_test
-  #       - echo -e "\n# tensor_test"
-  #       - ./tensor_test
-  #       - echo -e "\n# tensor_higher_rank_test"
-  #       - ./tensor_higher_rank_test
-  #       - echo -e "\n# 4photons"
-  #       - ./4photons
-  #       - echo -e "\n# 6photons"
-  #       - ./6photons
-  #       - echo -e "\n# ttbarh"
-  #       - ./ttbarh
+        - cd examples
+        - echo -e "\n# simple_test"
+        - ./simple_test
+        - echo -e "\n# simple_higher_rank_test"
+        - ./simple_higher_rank_test
+        - echo -e "\n# tensor_test"
+        - ./tensor_test
+        - echo -e "\n# tensor_higher_rank_test"
+        - ./tensor_higher_rank_test
+        - echo -e "\n# 4photons"
+        - ./4photons
+        - echo -e "\n# 6photons"
+        - ./6photons
+        - echo -e "\n# ttbarh"
+        - ./ttbarh
 
-  #       # Show how to build manually
-  #       - make clean
-  #       - echo -e "\n# simple_test by hand"
-  #     {% if (linux and (x86_64 or ppc64le)) %}
-  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
-  #     {% else %}
-  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
-  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
-  #     {% endif %}
-  #       - ./simple_test
+        # Show how to build manually
+        - make clean
+        - echo -e "\n# simple_test by hand"
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
+      {% else %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
+      {% endif %}
+        - ./simple_test
 
-  #       - make clean
-  #       - cd ..
-  #       - make clean
+        - make clean
+        - cd ..
+        - make clean
 
   - name: {{ name }}-hep-ph-static
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,142 +159,142 @@ outputs:
         - cd ..
         - make clean
 
-  - name: {{ name }}-hep-ph-static
+  # - name: {{ name }}-hep-ph-static
 
-    script: build_static.sh
+  #   script: build_static.sh
 
-    build:
-      skip: true  # [win]
+  #   build:
+  #     skip: true  # [win]
 
-    requirements:
-      build:
-        - {{ stdlib('c') }}
-        - {{ compiler('cxx') }}
-        - {{ compiler('fortran') }}
-        - automake  # includes autoconf
-        - libtool
-        - make
-        - pkg-config
-        - gnuconfig
-        - oneloop-static  # [build_platform != target_platform]
-        - looptools-static  # [(build_platform != target_platform) and (not (osx and arm64))]
-      host:
-        - oneloop-static
-        - looptools-static  # [not (osx and arm64)]
+  #   requirements:
+  #     build:
+  #       - {{ stdlib('c') }}
+  #       - {{ compiler('cxx') }}
+  #       - {{ compiler('fortran') }}
+  #       - automake  # includes autoconf
+  #       - libtool
+  #       - make
+  #       - pkg-config
+  #       - gnuconfig
+  #       - oneloop-static  # [build_platform != target_platform]
+  #       - looptools-static  # [(build_platform != target_platform) and (not (osx and arm64))]
+  #     host:
+  #       - oneloop-static
+  #       - looptools-static  # [not (osx and arm64)]
 
-    test:
-      # As need to regenerate Makefiles, need all of the source files that
-      # configure uses to do so
-      source_files:
-        - examples/
-        - m4/
-        - src/
-        - Makefile.am
-        - configure.ac
-      requires:
-        - {{ compiler('cxx') }}
-        - {{ compiler('fortran') }}
-        - automake
-        - libtool
-        - make
-        # libooptools.a and libavh_olo.a are needed at linktime, but not at runtime
-        - looptools-static  # [not (osx and arm64)]
-        - oneloop-static
-      commands:
-        - test -f $PREFIX/lib/libninja.a
-        # c.f. https://github.com/conda/conda-build/issues/3075
-        - test ! -f $PREFIX/lib/libninja.la
-        - test ! -f $PREFIX/lib/libninja${SHLIB_EXT}
-        - test -f $PREFIX/bin/ninja-config
-        - test -f $PREFIX/include/mninja.mod
-        - test -f $PREFIX/include/ninja/avholo.hh
-        - test -f $PREFIX/include/ninja/integral_library.hh
-        - test -f $PREFIX/include/ninja/looptools.hh
-        - test -f $PREFIX/include/ninja/momentum.hh
-        - test -f $PREFIX/include/ninja/ninja.hh
-        - test -f $PREFIX/include/ninja/ninja_config.h
-        - test -f $PREFIX/include/ninja/ninja_in.hh
-        - test -f $PREFIX/include/ninja/ninjanumgen.hh
-        - test -f $PREFIX/include/ninja/num_defs.hh
-        - test -f $PREFIX/include/ninja/rambo.hh
-        - test -f $PREFIX/include/ninja/s_mat.hh
-        - test -f $PREFIX/include/ninja/spinors.hh
-        - test -f $PREFIX/include/ninja/static_arrays.hh
-        - test -f $PREFIX/include/ninja/tensor_ninja.hh
-        - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
-        - test -f $PREFIX/include/ninja/types.hh
-        - test -f $PREFIX/include/ninja/zero_float.hh
-        - test -f $PREFIX/include/ninjago_module.mod
-        - test -f $PREFIX/include/ninjavholo.mod
-      {% if (linux and (x86_64 or ppc64le)) %}
-        - test -f $PREFIX/include/quadninja/avholo.hh
-        - test -f $PREFIX/include/quadninja/integral_library.hh
-        - test -f $PREFIX/include/quadninja/looptools.hh
-        - test -f $PREFIX/include/quadninja/momentum.hh
-        - test -f $PREFIX/include/quadninja/ninja.hh
-        - test -f $PREFIX/include/quadninja/ninja_config.h
-        - test -f $PREFIX/include/quadninja/ninja_in.hh
-        - test -f $PREFIX/include/quadninja/ninjanumgen.hh
-        - test -f $PREFIX/include/quadninja/num_defs.hh
-        - test -f $PREFIX/include/quadninja/quadruple.hh
-        - test -f $PREFIX/include/quadninja/rambo.hh
-        - test -f $PREFIX/include/quadninja/s_mat.hh
-        - test -f $PREFIX/include/quadninja/spinors.hh
-        - test -f $PREFIX/include/quadninja/static_arrays.hh
-        - test -f $PREFIX/include/quadninja/tensor_ninja.hh
-        - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
-        - test -f $PREFIX/include/quadninja/types.hh
-        - test -f $PREFIX/include/quadninja/zero_float.hh
-      {% else %}
-        - test ! -d $PREFIX/include/quadninja
-      {% endif %}
+  #   test:
+  #     # As need to regenerate Makefiles, need all of the source files that
+  #     # configure uses to do so
+  #     source_files:
+  #       - examples/
+  #       - m4/
+  #       - src/
+  #       - Makefile.am
+  #       - configure.ac
+  #     requires:
+  #       - {{ compiler('cxx') }}
+  #       - {{ compiler('fortran') }}
+  #       - automake
+  #       - libtool
+  #       - make
+  #       # libooptools.a and libavh_olo.a are needed at linktime, but not at runtime
+  #       - looptools-static  # [not (osx and arm64)]
+  #       - oneloop-static
+  #     commands:
+  #       - test -f $PREFIX/lib/libninja.a
+  #       # c.f. https://github.com/conda/conda-build/issues/3075
+  #       - test ! -f $PREFIX/lib/libninja.la
+  #       - test ! -f $PREFIX/lib/libninja${SHLIB_EXT}
+  #       - test -f $PREFIX/bin/ninja-config
+  #       - test -f $PREFIX/include/mninja.mod
+  #       - test -f $PREFIX/include/ninja/avholo.hh
+  #       - test -f $PREFIX/include/ninja/integral_library.hh
+  #       - test -f $PREFIX/include/ninja/looptools.hh
+  #       - test -f $PREFIX/include/ninja/momentum.hh
+  #       - test -f $PREFIX/include/ninja/ninja.hh
+  #       - test -f $PREFIX/include/ninja/ninja_config.h
+  #       - test -f $PREFIX/include/ninja/ninja_in.hh
+  #       - test -f $PREFIX/include/ninja/ninjanumgen.hh
+  #       - test -f $PREFIX/include/ninja/num_defs.hh
+  #       - test -f $PREFIX/include/ninja/rambo.hh
+  #       - test -f $PREFIX/include/ninja/s_mat.hh
+  #       - test -f $PREFIX/include/ninja/spinors.hh
+  #       - test -f $PREFIX/include/ninja/static_arrays.hh
+  #       - test -f $PREFIX/include/ninja/tensor_ninja.hh
+  #       - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
+  #       - test -f $PREFIX/include/ninja/types.hh
+  #       - test -f $PREFIX/include/ninja/zero_float.hh
+  #       - test -f $PREFIX/include/ninjago_module.mod
+  #       - test -f $PREFIX/include/ninjavholo.mod
+  #     {% if (linux and (x86_64 or ppc64le)) %}
+  #       - test -f $PREFIX/include/quadninja/avholo.hh
+  #       - test -f $PREFIX/include/quadninja/integral_library.hh
+  #       - test -f $PREFIX/include/quadninja/looptools.hh
+  #       - test -f $PREFIX/include/quadninja/momentum.hh
+  #       - test -f $PREFIX/include/quadninja/ninja.hh
+  #       - test -f $PREFIX/include/quadninja/ninja_config.h
+  #       - test -f $PREFIX/include/quadninja/ninja_in.hh
+  #       - test -f $PREFIX/include/quadninja/ninjanumgen.hh
+  #       - test -f $PREFIX/include/quadninja/num_defs.hh
+  #       - test -f $PREFIX/include/quadninja/quadruple.hh
+  #       - test -f $PREFIX/include/quadninja/rambo.hh
+  #       - test -f $PREFIX/include/quadninja/s_mat.hh
+  #       - test -f $PREFIX/include/quadninja/spinors.hh
+  #       - test -f $PREFIX/include/quadninja/static_arrays.hh
+  #       - test -f $PREFIX/include/quadninja/tensor_ninja.hh
+  #       - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
+  #       - test -f $PREFIX/include/quadninja/types.hh
+  #       - test -f $PREFIX/include/quadninja/zero_float.hh
+  #     {% else %}
+  #       - test ! -d $PREFIX/include/quadninja
+  #     {% endif %}
 
-        - ninja-config --help
-        - ninja-config --version
-        - ninja-config --quadsupport
+  #       - ninja-config --help
+  #       - ninja-config --version
+  #       - ninja-config --quadsupport
 
-        # Given the way the examples/Makefile works, need to regenerate it and
-        # other supporting files with configure again
-        - autoreconf --install
-      {% if (linux and (x86_64 or ppc64le)) %}
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
-      {% else %}
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
-      {% endif %}
-        - make examples
+  #       # Given the way the examples/Makefile works, need to regenerate it and
+  #       # other supporting files with configure again
+  #       - autoreconf --install
+  #     {% if (linux and (x86_64 or ppc64le)) %}
+  #       - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+  #     {% else %}
+  #       - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
+  #       - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
+  #     {% endif %}
+  #       - make examples
 
-        - cd examples
-        - echo -e "\n# simple_test"
-        - ./simple_test
-        - echo -e "\n# simple_higher_rank_test"
-        - ./simple_higher_rank_test
-        - echo -e "\n# tensor_test"
-        - ./tensor_test
-        - echo -e "\n# tensor_higher_rank_test"
-        - ./tensor_higher_rank_test
-        - echo -e "\n# 4photons"
-        - ./4photons
-        - echo -e "\n# 6photons"
-        - ./6photons
-        - echo -e "\n# ttbarh"
-        - ./ttbarh
+  #       - cd examples
+  #       - echo -e "\n# simple_test"
+  #       - ./simple_test
+  #       - echo -e "\n# simple_higher_rank_test"
+  #       - ./simple_higher_rank_test
+  #       - echo -e "\n# tensor_test"
+  #       - ./tensor_test
+  #       - echo -e "\n# tensor_higher_rank_test"
+  #       - ./tensor_higher_rank_test
+  #       - echo -e "\n# 4photons"
+  #       - ./4photons
+  #       - echo -e "\n# 6photons"
+  #       - ./6photons
+  #       - echo -e "\n# ttbarh"
+  #       - ./ttbarh
 
-        # Show how to build manually
-        - make clean
-        - echo -e "\n# simple_test by hand"
+  #       # Show how to build manually
+  #       - make clean
+  #       - echo -e "\n# simple_test by hand"
 
-      {% if (linux and (x86_64 or ppc64le)) %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
-      {% else %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
-      {% endif %}
-        - ./simple_test
+  #     {% if (linux and (x86_64 or ppc64le)) %}
+  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
+  #     {% else %}
+  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
+  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
+  #     {% endif %}
+  #       - ./simple_test
 
-        - make clean
-        - cd ..
-        - make clean
+  #       - make clean
+  #       - cd ..
+  #       - make clean
 
 about:
   home: https://github.com/peraro/ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -281,7 +281,8 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
-        - make examples
+        - make examples  # [not osx]
+        - make examples LIBNINJA="${LDFLAGS} -lninja -lavh_olo"  # [osx]
 
         - cd examples
         - echo -e "\n# simple_test"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,6 +129,11 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
+        # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
+        - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
+
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
       {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,7 +135,7 @@ outputs:
         - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
 
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
         - make clean
         - make examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,7 +78,7 @@ outputs:
         - test -f $PREFIX/include/mninja.mod
         - test -f $PREFIX/include/ninja/avholo.hh
         - test -f $PREFIX/include/ninja/integral_library.hh
-        - test -f $PREFIX/include/ninja/looptools.hh
+        - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
         - test -f $PREFIX/include/ninja/momentum.hh
         - test -f $PREFIX/include/ninja/ninja.hh
         - test -f $PREFIX/include/ninja/ninja_config.h
@@ -231,7 +231,7 @@ outputs:
         - test -f $PREFIX/include/mninja.mod
         - test -f $PREFIX/include/ninja/avholo.hh
         - test -f $PREFIX/include/ninja/integral_library.hh
-        - test -f $PREFIX/include/ninja/looptools.hh
+        - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
         - test -f $PREFIX/include/ninja/momentum.hh
         - test -f $PREFIX/include/ninja/ninja.hh
         - test -f $PREFIX/include/ninja/ninja_config.h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,7 +135,10 @@ outputs:
         - make examples
 
         - cd examples
+
         - otool -L simple_test  # [osx]
+        - otool -l simple_test | grep RPATH  # [osx]
+
         - echo -e "\n# simple_test"
         - ./simple_test
         - echo -e "\n# simple_higher_rank_test"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,8 +129,11 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
+        # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]  # linux-aarch64
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx]
       {% endif %}
         - make examples
 
@@ -160,8 +163,11 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
       {% else %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
+        # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]  # linux-aarch64
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
       {% endif %}
         - ./simple_test
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -281,6 +281,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
+        - grep exninjastatic configure.ac  # [osx]
+
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx]
       {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,6 +64,9 @@ outputs:
         - automake
         - libtool
         - make
+        - gawk
+        - sed
+        - grep
         # libooptools.a is needed at linktime, but not at runtime
         - looptools-static  # [not (osx and arm64)]
       commands:
@@ -162,142 +165,148 @@ outputs:
         - cd ..
         - make clean
 
-  # - name: {{ name }}-hep-ph-static
+  - name: {{ name }}-hep-ph-static
 
-  #   script: build_static.sh
+    script: build_static.sh
 
-  #   build:
-  #     skip: true  # [win]
+    build:
+      skip: true  # [win]
 
-  #   requirements:
-  #     build:
-  #       - {{ stdlib('c') }}
-  #       - {{ compiler('cxx') }}
-  #       - {{ compiler('fortran') }}
-  #       - automake  # includes autoconf
-  #       - libtool
-  #       - make
-  #       - pkg-config
-  #       - gnuconfig
-  #       - oneloop-static  # [build_platform != target_platform]
-  #       - looptools-static  # [(build_platform != target_platform) and (not (osx and arm64))]
-  #     host:
-  #       - oneloop-static
-  #       - looptools-static  # [not (osx and arm64)]
+    requirements:
+      build:
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}
+        - {{ compiler('fortran') }}
+        - automake  # includes autoconf
+        - libtool
+        - make
+        - pkg-config
+        - gnuconfig
+        - gawk
+        - sed
+        - grep
+        - oneloop-static  # [build_platform != target_platform]
+        - looptools-static  # [(build_platform != target_platform) and (not (osx and arm64))]
+      host:
+        - oneloop-static
+        - looptools-static  # [not (osx and arm64)]
 
-  #   test:
-  #     # As need to regenerate Makefiles, need all of the source files that
-  #     # configure uses to do so
-  #     source_files:
-  #       - examples/
-  #       - m4/
-  #       - src/
-  #       - Makefile.am
-  #       - configure.ac
-  #     requires:
-  #       - {{ compiler('cxx') }}
-  #       - {{ compiler('fortran') }}
-  #       - automake
-  #       - libtool
-  #       - make
-  #       # libooptools.a and libavh_olo.a are needed at linktime, but not at runtime
-  #       - looptools-static  # [not (osx and arm64)]
-  #       - oneloop-static
-  #     commands:
-  #       - test -f $PREFIX/lib/libninja.a
-  #       # c.f. https://github.com/conda/conda-build/issues/3075
-  #       - test ! -f $PREFIX/lib/libninja.la
-  #       - test ! -f $PREFIX/lib/libninja${SHLIB_EXT}
-  #       - test -f $PREFIX/bin/ninja-config
-  #       - test -f $PREFIX/include/mninja.mod
-  #       - test -f $PREFIX/include/ninja/avholo.hh
-  #       - test -f $PREFIX/include/ninja/integral_library.hh
-  #       - test -f $PREFIX/include/ninja/looptools.hh
-  #       - test -f $PREFIX/include/ninja/momentum.hh
-  #       - test -f $PREFIX/include/ninja/ninja.hh
-  #       - test -f $PREFIX/include/ninja/ninja_config.h
-  #       - test -f $PREFIX/include/ninja/ninja_in.hh
-  #       - test -f $PREFIX/include/ninja/ninjanumgen.hh
-  #       - test -f $PREFIX/include/ninja/num_defs.hh
-  #       - test -f $PREFIX/include/ninja/rambo.hh
-  #       - test -f $PREFIX/include/ninja/s_mat.hh
-  #       - test -f $PREFIX/include/ninja/spinors.hh
-  #       - test -f $PREFIX/include/ninja/static_arrays.hh
-  #       - test -f $PREFIX/include/ninja/tensor_ninja.hh
-  #       - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
-  #       - test -f $PREFIX/include/ninja/types.hh
-  #       - test -f $PREFIX/include/ninja/zero_float.hh
-  #       - test -f $PREFIX/include/ninjago_module.mod
-  #       - test -f $PREFIX/include/ninjavholo.mod
-  #     {% if (linux and (x86_64 or ppc64le)) %}
-  #       - test -f $PREFIX/include/quadninja/avholo.hh
-  #       - test -f $PREFIX/include/quadninja/integral_library.hh
-  #       - test -f $PREFIX/include/quadninja/looptools.hh
-  #       - test -f $PREFIX/include/quadninja/momentum.hh
-  #       - test -f $PREFIX/include/quadninja/ninja.hh
-  #       - test -f $PREFIX/include/quadninja/ninja_config.h
-  #       - test -f $PREFIX/include/quadninja/ninja_in.hh
-  #       - test -f $PREFIX/include/quadninja/ninjanumgen.hh
-  #       - test -f $PREFIX/include/quadninja/num_defs.hh
-  #       - test -f $PREFIX/include/quadninja/quadruple.hh
-  #       - test -f $PREFIX/include/quadninja/rambo.hh
-  #       - test -f $PREFIX/include/quadninja/s_mat.hh
-  #       - test -f $PREFIX/include/quadninja/spinors.hh
-  #       - test -f $PREFIX/include/quadninja/static_arrays.hh
-  #       - test -f $PREFIX/include/quadninja/tensor_ninja.hh
-  #       - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
-  #       - test -f $PREFIX/include/quadninja/types.hh
-  #       - test -f $PREFIX/include/quadninja/zero_float.hh
-  #     {% else %}
-  #       - test ! -d $PREFIX/include/quadninja
-  #     {% endif %}
+    test:
+      # As need to regenerate Makefiles, need all of the source files that
+      # configure uses to do so
+      source_files:
+        - examples/
+        - m4/
+        - src/
+        - Makefile.am
+        - configure.ac
+      requires:
+        - {{ compiler('cxx') }}
+        - {{ compiler('fortran') }}
+        - automake
+        - libtool
+        - make
+        - gawk
+        - sed
+        - grep
+        # libooptools.a and libavh_olo.a are needed at linktime, but not at runtime
+        - looptools-static  # [not (osx and arm64)]
+        - oneloop-static
+      commands:
+        - test -f $PREFIX/lib/libninja.a
+        # c.f. https://github.com/conda/conda-build/issues/3075
+        - test ! -f $PREFIX/lib/libninja.la
+        - test ! -f $PREFIX/lib/libninja${SHLIB_EXT}
+        - test -f $PREFIX/bin/ninja-config
+        - test -f $PREFIX/include/mninja.mod
+        - test -f $PREFIX/include/ninja/avholo.hh
+        - test -f $PREFIX/include/ninja/integral_library.hh
+        - test -f $PREFIX/include/ninja/looptools.hh
+        - test -f $PREFIX/include/ninja/momentum.hh
+        - test -f $PREFIX/include/ninja/ninja.hh
+        - test -f $PREFIX/include/ninja/ninja_config.h
+        - test -f $PREFIX/include/ninja/ninja_in.hh
+        - test -f $PREFIX/include/ninja/ninjanumgen.hh
+        - test -f $PREFIX/include/ninja/num_defs.hh
+        - test -f $PREFIX/include/ninja/rambo.hh
+        - test -f $PREFIX/include/ninja/s_mat.hh
+        - test -f $PREFIX/include/ninja/spinors.hh
+        - test -f $PREFIX/include/ninja/static_arrays.hh
+        - test -f $PREFIX/include/ninja/tensor_ninja.hh
+        - test -f $PREFIX/include/ninja/thread_safe_integral_library.hh
+        - test -f $PREFIX/include/ninja/types.hh
+        - test -f $PREFIX/include/ninja/zero_float.hh
+        - test -f $PREFIX/include/ninjago_module.mod
+        - test -f $PREFIX/include/ninjavholo.mod
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - test -f $PREFIX/include/quadninja/avholo.hh
+        - test -f $PREFIX/include/quadninja/integral_library.hh
+        - test -f $PREFIX/include/quadninja/looptools.hh
+        - test -f $PREFIX/include/quadninja/momentum.hh
+        - test -f $PREFIX/include/quadninja/ninja.hh
+        - test -f $PREFIX/include/quadninja/ninja_config.h
+        - test -f $PREFIX/include/quadninja/ninja_in.hh
+        - test -f $PREFIX/include/quadninja/ninjanumgen.hh
+        - test -f $PREFIX/include/quadninja/num_defs.hh
+        - test -f $PREFIX/include/quadninja/quadruple.hh
+        - test -f $PREFIX/include/quadninja/rambo.hh
+        - test -f $PREFIX/include/quadninja/s_mat.hh
+        - test -f $PREFIX/include/quadninja/spinors.hh
+        - test -f $PREFIX/include/quadninja/static_arrays.hh
+        - test -f $PREFIX/include/quadninja/tensor_ninja.hh
+        - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
+        - test -f $PREFIX/include/quadninja/types.hh
+        - test -f $PREFIX/include/quadninja/zero_float.hh
+      {% else %}
+        - test ! -d $PREFIX/include/quadninja
+      {% endif %}
 
-  #       - ninja-config --help
-  #       - ninja-config --version
-  #       - ninja-config --quadsupport
+        - ninja-config --help
+        - ninja-config --version
+        - ninja-config --quadsupport
 
-  #       # Given the way the examples/Makefile works, need to regenerate it and
-  #       # other supporting files with configure again
-  #       - autoreconf --install
-  #     {% if (linux and (x86_64 or ppc64le)) %}
-  #       - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
-  #     {% else %}
-  #       - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
-  #       - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
-  #     {% endif %}
-  #       - make examples
+        # Given the way the examples/Makefile works, need to regenerate it and
+        # other supporting files with configure again
+        - autoreconf --install
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+      {% else %}
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
+      {% endif %}
+        - make examples
 
-  #       - cd examples
-  #       - echo -e "\n# simple_test"
-  #       - ./simple_test
-  #       - echo -e "\n# simple_higher_rank_test"
-  #       - ./simple_higher_rank_test
-  #       - echo -e "\n# tensor_test"
-  #       - ./tensor_test
-  #       - echo -e "\n# tensor_higher_rank_test"
-  #       - ./tensor_higher_rank_test
-  #       - echo -e "\n# 4photons"
-  #       - ./4photons
-  #       - echo -e "\n# 6photons"
-  #       - ./6photons
-  #       - echo -e "\n# ttbarh"
-  #       - ./ttbarh
+        - cd examples
+        - echo -e "\n# simple_test"
+        - ./simple_test
+        - echo -e "\n# simple_higher_rank_test"
+        - ./simple_higher_rank_test
+        - echo -e "\n# tensor_test"
+        - ./tensor_test
+        - echo -e "\n# tensor_higher_rank_test"
+        - ./tensor_higher_rank_test
+        - echo -e "\n# 4photons"
+        - ./4photons
+        - echo -e "\n# 6photons"
+        - ./6photons
+        - echo -e "\n# ttbarh"
+        - ./ttbarh
 
-  #       # Show how to build manually
-  #       - make clean
-  #       - echo -e "\n# simple_test by hand"
+        # Show how to build manually
+        - make clean
+        - echo -e "\n# simple_test by hand"
 
-  #     {% if (linux and (x86_64 or ppc64le)) %}
-  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
-  #     {% else %}
-  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
-  #       - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
-  #     {% endif %}
-  #       - ./simple_test
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
+      {% else %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
+      {% endif %}
+        - ./simple_test
 
-  #       - make clean
-  #       - cd ..
-  #       - make clean
+        - make clean
+        - cd ..
+        - make clean
 
 about:
   home: https://github.com/peraro/ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,10 +38,11 @@ outputs:
         - pkg-config
         - gnuconfig
         - oneloop  # [build_platform != target_platform]
-        - looptools-static  # [build_platform != target_platform]
+        # FIXME: Add looptools for osx-arm64
+        - looptools-static  # [(build_platform != target_platform) and (not (osx and arm64))]
       host:
         - oneloop
-        - looptools-static
+        - looptools-static  # [not (osx and arm64)]
       run:
         - oneloop
 
@@ -61,7 +62,7 @@ outputs:
         - libtool
         - make
         # libooptools.a is needed at linktime, but not at runtime
-        - looptools-static
+        - looptools-static  # [not (osx and arm64)]
       commands:
         - test -f $PREFIX/lib/libninja${SHLIB_EXT}
         # c.f. https://github.com/conda/conda-build/issues/3075
@@ -122,7 +123,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
       {% endif %}
         - make examples
 
@@ -148,7 +150,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
       {% else %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
       {% endif %}
         - ./simple_test
 
@@ -174,10 +177,10 @@ outputs:
         - pkg-config
         - gnuconfig
         - oneloop-static  # [build_platform != target_platform]
-        - looptools-static  # [build_platform != target_platform]
+        - looptools-static  # [(build_platform != target_platform) and (not (osx and arm64))]
       host:
         - oneloop-static
-        - looptools-static
+        - looptools-static  # [not (osx and arm64)]
 
     test:
       # As need to regenerate Makefiles, need all of the source files that
@@ -195,7 +198,7 @@ outputs:
         - libtool
         - make
         # libooptools.a and libavh_olo.a are needed at linktime, but not at runtime
-        - looptools-static
+        - looptools-static  # [not (osx and arm64)]
         - oneloop-static
       commands:
         - test -f $PREFIX/lib/libninja.a
@@ -256,7 +259,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
       {% endif %}
         - make examples
 
@@ -283,7 +287,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
       {% else %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
       {% endif %}
         - ./simple_test
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,10 +42,10 @@ outputs:
         - grep
         - oneloop  # [build_platform != target_platform]
         # FIXME: Add looptools for osx-arm64
-        - looptools-static  # [(build_platform != target_platform) and (not (osx and arm64))]
+        - looptools-static  # [(build_platform != target_platform) and (not osx)]
       host:
         - oneloop
-        - looptools-static  # [not (osx and arm64)]
+        - looptools-static  # [not osx]
       run:
         - oneloop
 
@@ -68,7 +68,7 @@ outputs:
         - sed
         - grep
         # libooptools.a is needed at linktime, but not at runtime
-        - looptools-static  # [not (osx and arm64)]
+        - looptools-static  # [not osx]
       commands:
         - test -f $PREFIX/lib/libninja${SHLIB_EXT}
         # c.f. https://github.com/conda/conda-build/issues/3075
@@ -191,10 +191,10 @@ outputs:
         - sed
         - grep
         - oneloop-static  # [build_platform != target_platform]
-        - looptools-static  # [(build_platform != target_platform) and (not (osx and arm64))]
+        - looptools-static  # [(build_platform != target_platform) and (not osx)]
       host:
         - oneloop-static
-        - looptools-static  # [not (osx and arm64)]
+        - looptools-static  # [not osx]
 
     test:
       # As need to regenerate Makefiles, need all of the source files that
@@ -215,7 +215,7 @@ outputs:
         - sed
         - grep
         # libooptools.a and libavh_olo.a are needed at linktime, but not at runtime
-        - looptools-static  # [not (osx and arm64)]
+        - looptools-static  # [not osx]
         - oneloop-static
       commands:
         - test -f $PREFIX/lib/libninja.a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,7 +135,7 @@ outputs:
         - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
 
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]  # [osx]
       {% endif %}
         - make clean
         - make examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,8 +135,8 @@ outputs:
         - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
         - grep exninjastatic configure.ac  # [osx]
 
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx]
       {% endif %}
         - make examples
 
@@ -281,8 +281,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx]
       {% endif %}
         - make examples
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -277,7 +277,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" LIBS="-lstdc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" LIBS="-lstdc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
         - make examples
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -133,7 +133,6 @@ outputs:
         # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
         # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
         - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
-        - grep exninjastatic configure.ac  # [osx]
 
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx]
@@ -141,10 +140,6 @@ outputs:
         - make examples
 
         - cd examples
-
-        - otool -L simple_test  # [osx]
-        - otool -l simple_test | grep RPATH  # [osx]
-
         - echo -e "\n# simple_test"
         - ./simple_test
         - echo -e "\n# simple_higher_rank_test"
@@ -281,8 +276,6 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
-        - grep exninjastatic configure.ac  # [osx]
-
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
       {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -274,7 +274,6 @@ outputs:
 
         # Given the way the examples/Makefile works, need to regenerate it and
         # other supporting files with configure again
-        - cp $BUILD_PREFIX/share/gnuconfig/config.* .
         - autoreconf --install
       {% if (linux and (x86_64 or ppc64le)) %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -137,6 +137,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
         - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx]
       {% endif %}
+        - make clean
         - make examples
 
         - cd examples
@@ -281,6 +282,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
+        - make clean
         - make examples
 
         - cd examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -231,7 +231,7 @@ outputs:
         - test -f $PREFIX/include/mninja.mod
         - test -f $PREFIX/include/ninja/avholo.hh
         - test -f $PREFIX/include/ninja/integral_library.hh
-        - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
+        - test -f $PREFIX/include/ninja/looptools.hh  # [not (osx and arm64)]
         - test -f $PREFIX/include/ninja/momentum.hh
         - test -f $PREFIX/include/ninja/ninja.hh
         - test -f $PREFIX/include/ninja/ninja_config.h
@@ -283,8 +283,8 @@ outputs:
       {% else %}
         - grep exninjastatic configure.ac  # [osx]
 
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not (osx and arm64)]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
       {% endif %}
         - make examples
 
@@ -311,8 +311,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
       {% else %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
       {% endif %}
         - ./simple_test
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -217,8 +217,8 @@ outputs:
         - sed
         - grep
         # libooptools.a and libavh_olo.a are needed at linktime, but not at runtime
-        - looptools-static  # [not osx]
         - oneloop-static
+        - looptools-static  # [not osx]
       commands:
         - test -f $PREFIX/lib/libninja.a
         # c.f. https://github.com/conda/conda-build/issues/3075

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,9 @@ outputs:
         - make
         - pkg-config
         - gnuconfig
+        - gawk
+        - sed
+        - grep
         - oneloop  # [build_platform != target_platform]
         # FIXME: Add looptools for osx-arm64
         - looptools-static  # [(build_platform != target_platform) and (not (osx and arm64))]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -226,7 +226,7 @@ outputs:
         - test -f $PREFIX/include/mninja.mod
         - test -f $PREFIX/include/ninja/avholo.hh
         - test -f $PREFIX/include/ninja/integral_library.hh
-        - test -f $PREFIX/include/ninja/looptools.hh  # [not (osx and arm64)]
+        - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
         - test -f $PREFIX/include/ninja/momentum.hh
         - test -f $PREFIX/include/ninja/ninja.hh
         - test -f $PREFIX/include/ninja/ninja_config.h
@@ -277,8 +277,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx and x86_64]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [osx and arm64]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
         - make examples
 
@@ -305,8 +304,8 @@ outputs:
       {% if (linux and (x86_64 or ppc64le)) %}
         - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
       {% else %}
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not (osx and arm64)]
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx and arm64]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
       {% endif %}
         - ./simple_test
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -277,7 +277,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" LIBS="-lstdc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
         - make examples
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -277,7 +277,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" LIBS="-lstdc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
         - make examples
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -281,8 +281,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
-        - make examples  # [not osx]
-        - make examples LIBNINJA="${LDFLAGS} -lninja -lavh_olo"  # [osx]
+        - make examples
 
         - cd examples
         - echo -e "\n# simple_test"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -280,7 +280,7 @@ outputs:
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
       {% else %}
         - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
       {% endif %}
         - make clean
         - make examples

--- a/recipe/remove-version-file.patch
+++ b/recipe/remove-version-file.patch
@@ -1,0 +1,25 @@
+From 51ea5e2c974e5856d613cfb548760a80f7a56edc Mon Sep 17 00:00:00 2001
+From: Matthew Feickert <matthew.feickert@cern.ch>
+Date: Thu, 20 Feb 2025 02:37:48 -0700
+Subject: [PATCH] fix: Remove VERSION file to allow for macOS builds
+
+* As macOS file names are not case sensitive, VERSION is viewed as another
+  file 'version' for macOS builds with clang.
+* The file is not required by use of downstream projects anymore, and so
+  can safely be removed.
+---
+ VERSION | 1 -
+ 1 file changed, 1 deletion(-)
+ delete mode 100644 VERSION
+
+diff --git a/VERSION b/VERSION
+deleted file mode 100644
+index 867e524..0000000
+--- a/VERSION
++++ /dev/null
+@@ -1 +0,0 @@
+-1.2.0
+\ No newline at end of file
+-- 
+2.48.1
+


### PR DESCRIPTION
* Enable quadninja optionally based on if libquadmath is available.
* Add osx and linux-aarch64 builds.
   - Add gawk, grep, and sed as 'build' and 'test' requirements to use the correct versions.
   - Don't build against looptools-static on macOS arm64, as there isn't a build for osx-arm64 yet.
   - Add patch from https://github.com/peraro/ninja/pull/6 to remove VERSION file.
* Add ABI migration rebuilds for ninja-hep-ph v1.1.0 on branch 1.x.
* Bump build number.

Context: Needed for https://github.com/conda-forge/mg5amcnlo-feedstock/pull/3 and https://github.com/conda-forge/mg5amcnlo-feedstock/pull/6

Resolves https://github.com/conda-forge/ninja-hep-ph-feedstock/issues/6

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
