### PR TITLE
ENH: Backport macOS and Linux aarch64 support

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,10 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,0 +1,40 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: osx
+  pool:
+    vmImage: macOS-13
+  strategy:
+    matrix:
+      osx_64_:
+        CONFIG: osx_64_
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables: {}
+
+  steps:
+  # TODO: Fast finish on azure pipelines?
+  - script: |
+      export CI=azure
+      export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+      export remote_url=$(Build.Repository.Uri)
+      export sha=$(Build.SourceVersion)
+      export OSX_FORCE_SDK_DOWNLOAD="1"
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+        export IS_PR_BUILD="True"
+      else
+        export IS_PR_BUILD="False"
+      fi
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,25 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,0 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+zip_keys:
+- - cxx_compiler_version
+  - fortran_compiler_version

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# -*- mode: jinja-shell -*-
+
+source .scripts/logging_utils.sh
+
+set -xe
+
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
+
+( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
+MICROMAMBA_VERSION="1.5.10-0"
+if [[ "$(uname -m)" == "arm64" ]]; then
+  osx_arch="osx-arm64"
+else
+  osx_arch="osx-64"
+fi
+MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
+MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
+echo "Downloading micromamba ${MICROMAMBA_VERSION}"
+micromamba_exe="$(mktemp -d)/micromamba"
+curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
+chmod +x "${micromamba_exe}"
+echo "Creating environment"
+"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
+  --channel conda-forge \
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
+mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
+echo "Cleaning up micromamba"
+rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
+( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
+
+( startgroup "Configuring conda" ) 2> /dev/null
+echo "Activating environment"
+source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
+conda activate base
+export CONDA_SOLVER="libmamba"
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
+
+
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+if [[ "${CI:-}" != "" ]]; then
+  mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+fi
+
+if [[ "${CI:-}" != "" ]]; then
+  echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+  /usr/bin/sudo mangle_homebrew
+  /usr/bin/sudo -k
+else
+  echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
+
+if [[ "${sha:-}" == "" ]]; then
+  sha=$(git rev-parse HEAD)
+fi
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+
+( endgroup "Configuring conda" ) 2> /dev/null
+
+echo -e "\n\nMaking the build clobber file"
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+if [[ -f LICENSE.txt ]]; then
+  cp LICENSE.txt "recipe/recipe-scripts-license.txt"
+fi
+
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+
+    # Drop into an interactive shell
+    /bin/bash
+else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
+    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
+        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir ./recipe -m ./.ci_support/${CONFIG}.yaml || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
+      upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
+fi

--- a/README.md
+++ b/README.md
@@ -51,10 +51,31 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24224&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ninja-hep-ph-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24224&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ninja-hep-ph-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24224&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ninja-hep-ph-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24224&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ninja-hep-ph-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,3 +29,4 @@ stages:
   dependsOn: Check
   jobs:
     - template: ./.azure-pipelines/azure-pipelines-linux.yml
+    - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,14 +1,17 @@
 bot:
   abi_migration_branches:
-  - 1.x
-github:
-  branch_name: main
-  tooling_branch_name: main
+  - '1.x'
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+  osx_arm64: osx_64
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
-build_platform:
-  linux_ppc64le: linux_64
+github:
+  branch_name: main
+  tooling_branch_name: main
 provider:
+  linux_aarch64: default
   linux_ppc64le: default
 test: native_and_emulated

--- a/recipe/build_shared.sh
+++ b/recipe/build_shared.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+set -xe
+
+export DISABLE_QUADMATH=false
+
+# libquadmath not supported on macOS or aarch64
+if [[ "$(uname)" == "Darwin" ]]; then
+    export DISABLE_QUADMATH=true
+fi
+if [[ "${target_platform}" == linux-aarch64 ]]; then
+    export DISABLE_QUADMATH=true
+fi
+
 # c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#cross-compilation-examples
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/gnuconfig/config.* .
@@ -10,15 +22,42 @@ autoreconf --install
 
 # Remove static library to comply with CFEP-18
 # https://github.com/conda-forge/cfep/blob/main/cfep-18.md
-./configure \
-    --prefix=$PREFIX \
-    --enable-shared=yes \
-    --enable-static=no \
-    --enable-higher_rank \
-    --enable-quadninja \
-    --with-avholo="$FFLAGS -lavh_olo" \
-    FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-    CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+if [[ "${DISABLE_QUADMATH}" == true ]]; then
+    echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
+    if [[ "$(uname)" == "Darwin" ]]; then
+        ./configure \
+            --prefix=$PREFIX \
+            --enable-shared=yes \
+            --enable-static=no \
+            --enable-higher_rank \
+            --disable-quadninja \
+            --with-avholo="$FFLAGS -lavh_olo" \
+            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+    else
+        ./configure \
+            --prefix=$PREFIX \
+            --enable-shared=yes \
+            --enable-static=no \
+            --enable-higher_rank \
+            --disable-quadninja \
+            --with-avholo="$FFLAGS -lavh_olo" \
+            --with-looptools="$FLDFLAGS -looptools -lgfortran" \
+            FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+            CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+    fi
+else
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-shared=yes \
+        --enable-static=no \
+        --enable-higher_rank \
+        --enable-quadninja \
+        --with-avholo="$FFLAGS -lavh_olo" \
+        --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" \
+        FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
+        CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+fi
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'
 make
@@ -29,3 +68,5 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR:
 fi
 make install
 make clean
+
+unset DISABLE_QUADMATH

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+set -xe
+
+export DISABLE_QUADMATH=false
+
+# libquadmath not supported on macOS or aarch64
+if [[ "$(uname)" == "Darwin" ]]; then
+    export DISABLE_QUADMATH=true
+fi
+if [[ "${target_platform}" == linux-aarch64 ]]; then
+    export DISABLE_QUADMATH=true
+fi
+
 # c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#cross-compilation-examples
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/gnuconfig/config.* .
@@ -8,15 +20,51 @@ autoreconf --install
 
 ./configure --help
 
-./configure \
-    --prefix=$PREFIX \
-    --enable-shared=no \
-    --enable-static=yes \
-    --enable-higher_rank \
-    --enable-quadninja \
-    --with-avholo="$FFLAGS -lavh_olo" \
-    FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" \
-    CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS"
+if [[ "${DISABLE_QUADMATH}" == true ]]; then
+    echo -e "\n# libquadmath not supported on target platform ${target_platform} so disabling quadninja."
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # Following https://github.com/mg5amcnlo/HEPToolsInstallers/blob/d56fe6c04242360076be533a653c187493ef1187/installNinja.sh#L18-L19
+        ./configure \
+            --prefix=$PREFIX \
+            --enable-shared=no \
+            --enable-static=yes \
+            --enable-higher_rank \
+            --disable-quadninja \
+            --with-avholo="${FFLAGS} -lavh_olo -lgfortran" \
+            FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop" \
+            CXX="${CXX}" \
+            CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" \
+            CPPFLAGS="-DNINJA_NO_EXCEPTIONS -fPIC ${CPPFLAGS}" \
+            LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}" \
+            LIBS="-lc++"
+    else
+        ./configure \
+            --prefix=$PREFIX \
+            --enable-shared=no \
+            --enable-static=yes \
+            --enable-higher_rank \
+            --disable-quadninja \
+            --with-avholo="${FFLAGS} -lavh_olo" \
+            --with-looptools="${FLDFLAGS} -looptools -lgfortran" \
+            FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop" \
+            CXXFLAGS="${CXXFLAGS}" \
+            CPPFLAGS="-DNINJA_NO_EXCEPTIONS -fPIC ${CPPFLAGS}" \
+            LDFLAGS="${LDFLAGS}"
+    fi
+else
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-shared=no \
+        --enable-static=yes \
+        --enable-higher_rank \
+        --enable-quadninja \
+        --with-avholo="${FFLAGS} -lavh_olo" \
+        --with-looptools="${FLDFLAGS} -looptools -lgfortran -lquadmath" \
+        FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop" \
+        CXXFLAGS="${CXXFLAGS}" \
+        CPPFLAGS="-DNINJA_NO_EXCEPTIONS -fPIC ${CPPFLAGS}" \
+        LDFLAGS="${LDFLAGS}"
+fi
 
 # Makefile is not parallel safe so can't use 'make --jobs="${CPU_COUNT}"'
 make
@@ -27,3 +75,5 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR:
 fi
 make install
 make clean
+
+unset DISABLE_QUADMATH

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,13 @@ source:
   # https://github.com/peraro/ninja/releases/tag/v1.1.0 fails to compile so fall back to hepforge
   url: https://www.hepforge.org/archive/ninja/ninja-{{ version }}.tar.gz
   sha256: 04b544a8b9d3e5be28e60d7e808ee4a91e9e5196783148b5e6ec5046e78e836b
+  patches:
+    - posix-compliant-shell.patch
+    # c.f. https://github.com/peraro/ninja/issues/5
+    - remove-version-file.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}-hep-ph
@@ -21,8 +25,7 @@ outputs:
     script: build_shared.sh
 
     build:
-      # libquadmath is required, so macOS is not supported
-      skip: true  # [not linux]
+      skip: true  # [win]
       run_exports:
         - {{ pin_subpackage('ninja-hep-ph', max_pin='x.x') }}
 
@@ -36,9 +39,15 @@ outputs:
         - make
         - pkg-config
         - gnuconfig
+        - gawk
+        - sed
+        - grep
         - oneloop  # [build_platform != target_platform]
+        # FIXME: Add looptools for osx-arm64
+        - looptools-static  # [(build_platform != target_platform) and (not osx)]
       host:
         - oneloop
+        - looptools-static  # [not osx]
       run:
         - oneloop
 
@@ -57,6 +66,11 @@ outputs:
         - automake
         - libtool
         - make
+        - gawk
+        - sed
+        - grep
+        # libooptools.a is needed at linktime, but not at runtime
+        - looptools-static  # [not osx]
       commands:
         - test -f $PREFIX/lib/libninja${SHLIB_EXT}
         # c.f. https://github.com/conda/conda-build/issues/3075
@@ -66,6 +80,7 @@ outputs:
         - test -f $PREFIX/include/mninja.mod
         - test -f $PREFIX/include/ninja/avholo.hh
         - test -f $PREFIX/include/ninja/integral_library.hh
+        - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
         - test -f $PREFIX/include/ninja/momentum.hh
         - test -f $PREFIX/include/ninja/ninja.hh
         - test -f $PREFIX/include/ninja/ninja_config.h
@@ -82,8 +97,10 @@ outputs:
         - test -f $PREFIX/include/ninja/zero_float.hh
         - test -f $PREFIX/include/ninjago_module.mod
         - test -f $PREFIX/include/ninjavholo.mod
+      {% if (linux and (x86_64 or ppc64le)) %}
         - test -f $PREFIX/include/quadninja/avholo.hh
         - test -f $PREFIX/include/quadninja/integral_library.hh
+        - test -f $PREFIX/include/quadninja/looptools.hh
         - test -f $PREFIX/include/quadninja/momentum.hh
         - test -f $PREFIX/include/quadninja/ninja.hh
         - test -f $PREFIX/include/quadninja/ninja_config.h
@@ -99,6 +116,9 @@ outputs:
         - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
         - test -f $PREFIX/include/quadninja/types.hh
         - test -f $PREFIX/include/quadninja/zero_float.hh
+      {% else %}
+        - test ! -d $PREFIX/include/quadninja
+      {% endif %}
 
         - ninja-config --help
         - ninja-config --version
@@ -107,7 +127,19 @@ outputs:
         # Given the way the examples/Makefile works, need to regenerate it and
         # other supporting files with configure again
         - autoreconf --install
-        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+      {% else %}
+        # FIXME: If on macOS and --with-looptools is used, only the static library form of libninja will be looked for during 'make examples'.
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/configure.ac#L104-L109
+        # c.f. https://github.com/peraro/ninja/blob/a3109d76d08287d772f42552076aa1b0a877e96b/examples/Makefile.am#L36-L40
+        - sed -i 's/exninjastatic=true/exninjastatic=false/g' configure.ac  # [osx]
+
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --disable-quadninja --with-avholo="$FFLAGS -lavh_olo" --with-looptools="$FLDFLAGS -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"  # [not osx]
+        - ./configure --prefix=$PREFIX --enable-shared=yes --enable-static=no --enable-higher_rank --with-avholo="$FFLAGS -lavh_olo" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
+      {% endif %}
+        - make clean
         - make examples
 
         - cd examples
@@ -129,7 +161,12 @@ outputs:
         # Show how to build manually
         - make clean
         - echo -e "\n# simple_test by hand"
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran -lquadmath
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
+      {% else %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
+      {% endif %}
         - ./simple_test
 
         - make clean
@@ -141,8 +178,7 @@ outputs:
     script: build_static.sh
 
     build:
-      # libquadmath is required, so macOS is not supported
-      skip: true  # [not linux]
+      skip: true  # [win]
 
     requirements:
       build:
@@ -154,9 +190,14 @@ outputs:
         - make
         - pkg-config
         - gnuconfig
+        - gawk
+        - sed
+        - grep
         - oneloop-static  # [build_platform != target_platform]
+        - looptools-static  # [(build_platform != target_platform) and (not osx)]
       host:
         - oneloop-static
+        - looptools-static  # [not osx]
 
     test:
       # As need to regenerate Makefiles, need all of the source files that
@@ -173,8 +214,14 @@ outputs:
         - automake
         - libtool
         - make
-        # libavh_olo.a is needed at linktime, but not at runtime
+        - pkg-config
+        - gnuconfig
+        - gawk
+        - sed
+        - grep
+        # libooptools.a and libavh_olo.a are needed at linktime, but not at runtime
         - oneloop-static
+        - looptools-static  # [not osx]
       commands:
         - test -f $PREFIX/lib/libninja.a
         # c.f. https://github.com/conda/conda-build/issues/3075
@@ -184,6 +231,7 @@ outputs:
         - test -f $PREFIX/include/mninja.mod
         - test -f $PREFIX/include/ninja/avholo.hh
         - test -f $PREFIX/include/ninja/integral_library.hh
+        - test -f $PREFIX/include/ninja/looptools.hh  # [not osx]
         - test -f $PREFIX/include/ninja/momentum.hh
         - test -f $PREFIX/include/ninja/ninja.hh
         - test -f $PREFIX/include/ninja/ninja_config.h
@@ -200,8 +248,10 @@ outputs:
         - test -f $PREFIX/include/ninja/zero_float.hh
         - test -f $PREFIX/include/ninjago_module.mod
         - test -f $PREFIX/include/ninjavholo.mod
+      {% if (linux and (x86_64 or ppc64le)) %}
         - test -f $PREFIX/include/quadninja/avholo.hh
         - test -f $PREFIX/include/quadninja/integral_library.hh
+        - test -f $PREFIX/include/quadninja/looptools.hh
         - test -f $PREFIX/include/quadninja/momentum.hh
         - test -f $PREFIX/include/quadninja/ninja.hh
         - test -f $PREFIX/include/quadninja/ninja_config.h
@@ -217,6 +267,9 @@ outputs:
         - test -f $PREFIX/include/quadninja/thread_safe_integral_library.hh
         - test -f $PREFIX/include/quadninja/types.hh
         - test -f $PREFIX/include/quadninja/zero_float.hh
+      {% else %}
+        - test ! -d $PREFIX/include/quadninja
+      {% endif %}
 
         - ninja-config --help
         - ninja-config --version
@@ -225,7 +278,13 @@ outputs:
         # Given the way the examples/Makefile works, need to regenerate it and
         # other supporting files with configure again
         - autoreconf --install
-        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="$FFLAGS -lavh_olo $FLDFLAGS -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I$PREFIX/include/oneloop"
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --enable-quadninja --with-avholo="${FFLAGS} -lavh_olo" --with-looptools="${FLDFLAGS} -looptools -lgfortran -lquadmath" FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop"
+      {% else %}
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="${FFLAGS} -lavh_olo" --with-looptools="${FLDFLAGS} -looptools -lgfortran" FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop"  # [not osx]
+        - ./configure --prefix=$PREFIX --enable-shared=no --enable-static=yes --enable-higher_rank --disable-quadninja --with-avholo="${FFLAGS} -lavh_olo -lgfortran" FCINCLUDE="${FCINCLUDE} -I${PREFIX}/include/oneloop" CXX="${CXX}" CXXFLAGS="-O2 -fcx-fortran-rules -fno-exceptions -fno-rtti ${CXXFLAGS}" CPPFLAGS="${CPPFLAGS} -DNINJA_NO_EXCEPTIONS -fPIC" --disable-quadninja LIBS="-lc++" LDFLAGS="-Wl,-no_compact_unwind ${LDFLAGS}"  # [osx]
+      {% endif %}
+        - make clean
         - make examples
 
         - cd examples
@@ -247,7 +306,13 @@ outputs:
         # Show how to build manually
         - make clean
         - echo -e "\n# simple_test by hand"
-        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran -lquadmath
+
+      {% if (linux and (x86_64 or ppc64le)) %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran -lquadmath
+      {% else %}
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -looptools -lgfortran  # [not osx]
+        - $CXX simple_test.cc mynum.cc -o simple_test $CXXFLAGS -I./ -I$PREFIX/include/ninja $LDFLAGS -lninja -lavh_olo -lgfortran  # [osx]
+      {% endif %}
         - ./simple_test
 
         - make clean

--- a/recipe/remove-version-file.patch
+++ b/recipe/remove-version-file.patch
@@ -1,0 +1,25 @@
+From 51ea5e2c974e5856d613cfb548760a80f7a56edc Mon Sep 17 00:00:00 2001
+From: Matthew Feickert <matthew.feickert@cern.ch>
+Date: Thu, 20 Feb 2025 02:37:48 -0700
+Subject: [PATCH] fix: Remove VERSION file to allow for macOS builds
+
+* As macOS file names are not case sensitive, VERSION is viewed as another
+  file 'version' for macOS builds with clang.
+* The file is not required by use of downstream projects anymore, and so
+  can safely be removed.
+---
+ VERSION | 1 -
+ 1 file changed, 1 deletion(-)
+ delete mode 100644 VERSION
+
+diff --git a/VERSION b/VERSION
+deleted file mode 100644
+index 867e524..0000000
+--- a/VERSION
++++ /dev/null
+@@ -1 +0,0 @@
+-1.1.0
+\ No newline at end of file
+-- 
+2.48.1
+


### PR DESCRIPTION
* Backport PR https://github.com/conda-forge/ninja-hep-ph-feedstock/pull/8
* Enable quadninja optionally based on if libquadmath is available.
* Add osx and linux-aarch64 builds.
   - Add gawk, grep, and sed as 'build' and 'test' requirements to use the correct versions.
   - Don't build against looptools-static on macOS arm64, as there isn't a build for osx-arm64 yet.
   - Add patch to remove VERSION file.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
